### PR TITLE
Fix building dropdown saving issue

### DIFF
--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -268,7 +268,7 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
         model.building = value;
       },
       onSaved: (value) {
-        model.floor = value;
+        model.building = value;
       },
     );
   }


### PR DESCRIPTION
## Summary
- ensure building dropdown saves to `model.building`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840981febc08322b3d1df0c1368061b