### PR TITLE
Add Firestore service with offline support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,13 +5,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'existing_survey_screen.dart';
 import 'user_info/user_initial_info.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'survey_service.dart';
 
+final SurveyService surveyService = SurveyService();
 
 
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
+  await SurveyService.configureFirestoreCache();
+  surveyService.startConnectivityListener();
   runApp(
     ChangeNotifierProvider(
       create: (context) => UserInfoDialogStatus(),
@@ -20,8 +24,19 @@ void main() async {
   );
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  @override
+  void dispose() {
+    surveyService.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1,0 +1,147 @@
+// Data models for Firestore-based survey storage
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class SurveyHeader {
+  final DateTime surveyDate;
+  final String occupancyStatus;
+  final Map<String, dynamic> extra;
+
+  SurveyHeader({
+    required this.surveyDate,
+    required this.occupancyStatus,
+    this.extra = const {},
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'surveyDate': Timestamp.fromDate(surveyDate),
+      'occupancyStatus': occupancyStatus,
+      ...extra,
+    };
+  }
+
+  factory SurveyHeader.fromMap(Map<String, dynamic> map) {
+    final extra = Map<String, dynamic>.from(map)..remove('surveyDate')..remove('occupancyStatus');
+    return SurveyHeader(
+      surveyDate: (map['surveyDate'] as Timestamp).toDate(),
+      occupancyStatus: map['occupancyStatus'] ?? '',
+      extra: extra,
+    );
+  }
+}
+
+class Measurement {
+  final String building;
+  final int? floorNumber;
+  final String roomNumber;
+  final String primaryRoomUse;
+  final double? temperatureF;
+  final double? relativeHumidityPct;
+  final int? co2ppm;
+  final double? pm25mgm3;
+
+  Measurement({
+    required this.building,
+    this.floorNumber,
+    required this.roomNumber,
+    required this.primaryRoomUse,
+    this.temperatureF,
+    this.relativeHumidityPct,
+    this.co2ppm,
+    this.pm25mgm3,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'building': building,
+      'floorNumber': floorNumber,
+      'roomNumber': roomNumber,
+      'primaryRoomUse': primaryRoomUse,
+      'temperatureF': temperatureF,
+      'relativeHumidityPct': relativeHumidityPct,
+      'co2ppm': co2ppm,
+      'pm25mgm3': pm25mgm3,
+    };
+  }
+
+  factory Measurement.fromMap(Map<String, dynamic> map) => Measurement(
+        building: map['building'] ?? '',
+        floorNumber: map['floorNumber'],
+        roomNumber: map['roomNumber'] ?? '',
+        primaryRoomUse: map['primaryRoomUse'] ?? '',
+        temperatureF: (map['temperatureF'] as num?)?.toDouble(),
+        relativeHumidityPct: (map['relativeHumidityPct'] as num?)?.toDouble(),
+        co2ppm: map['co2ppm'],
+        pm25mgm3: (map['pm25mgm3'] as num?)?.toDouble(),
+      );
+}
+
+class VisualAssessment {
+  final String building;
+  final int? floorNumber;
+  final String roomNumber;
+  final String primaryRoomUse;
+  final String notes;
+
+  VisualAssessment({
+    required this.building,
+    this.floorNumber,
+    required this.roomNumber,
+    required this.primaryRoomUse,
+    required this.notes,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'building': building,
+      'floorNumber': floorNumber,
+      'roomNumber': roomNumber,
+      'primaryRoomUse': primaryRoomUse,
+      'notes': notes,
+    };
+  }
+
+  factory VisualAssessment.fromMap(Map<String, dynamic> map) => VisualAssessment(
+        building: map['building'] ?? '',
+        floorNumber: map['floorNumber'],
+        roomNumber: map['roomNumber'] ?? '',
+        primaryRoomUse: map['primaryRoomUse'] ?? '',
+        notes: map['notes'] ?? '',
+      );
+}
+
+class PhotoMetadata {
+  final String roomNumber;
+  final String downloadUrl;
+  final String fileName;
+  final DateTime? timestamp;
+
+  PhotoMetadata({
+    required this.roomNumber,
+    required this.downloadUrl,
+    required this.fileName,
+    this.timestamp,
+  });
+
+  factory PhotoMetadata.fromMap(Map<String, dynamic> map) => PhotoMetadata(
+        roomNumber: map['roomNumber'] ?? '',
+        downloadUrl: map['downloadUrl'] ?? '',
+        fileName: map['fileName'] ?? '',
+        timestamp: (map['timestamp'] as Timestamp?)?.toDate(),
+      );
+}
+
+class SurveyReport {
+  final SurveyHeader header;
+  final List<Measurement> measurements;
+  final List<VisualAssessment> visuals;
+  final List<PhotoMetadata> photos;
+
+  SurveyReport({
+    required this.header,
+    required this.measurements,
+    required this.visuals,
+    required this.photos,
+  });
+}
+

--- a/lib/survey_service.dart
+++ b/lib/survey_service.dart
@@ -1,0 +1,180 @@
+import 'dart:io';
+import 'dart:async';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'models.dart';
+
+class SurveyService {
+  StreamSubscription<ConnectivityResult>? _connectivitySub;
+
+  /// Configure Firestore persistence with ~15MB cache size.
+  static Future<void> configureFirestoreCache() async {
+    await FirebaseFirestore.instance.enablePersistence(
+      const PersistenceSettings(cacheSizeBytes: 15 * 1024 * 1024),
+    );
+  }
+
+  /// Start listening for connectivity changes.
+  void startConnectivityListener() {
+    _connectivitySub = Connectivity().onConnectivityChanged.listen((result) async {
+      if (result != ConnectivityResult.none) {
+        await uploadPendingImages();
+      }
+    });
+  }
+
+  /// Cancel connectivity subscription.
+  void dispose() {
+    _connectivitySub?.cancel();
+  }
+
+  /// Create a new survey offline with optional room images.
+  Future<String> createSurveyOffline({
+    required SurveyHeader header,
+    required List<Measurement> measurements,
+    required List<VisualAssessment> visuals,
+    Map<String, File>? roomImages,
+  }) async {
+    try {
+      final surveyRef = FirebaseFirestore.instance.collection('surveys').doc();
+      final batch = FirebaseFirestore.instance.batch();
+
+      batch.set(surveyRef, header.toMap());
+
+      for (final m in measurements) {
+        final doc = surveyRef.collection('measurements').doc();
+        batch.set(doc, m.toMap());
+      }
+
+      for (final v in visuals) {
+        final doc = surveyRef.collection('visualAssessments').doc();
+        batch.set(doc, v.toMap());
+      }
+
+      await batch.commit();
+
+      if (roomImages != null && roomImages.isNotEmpty) {
+        final tempDir = await getTemporaryDirectory();
+        final surveyDir = Directory(p.join(tempDir.path, 'surveyPending', surveyRef.id));
+        await surveyDir.create(recursive: true);
+        for (final entry in roomImages.entries) {
+          final destPath = p.join(surveyDir.path, 'room_${entry.key}.jpg');
+          await entry.value.copy(destPath);
+        }
+        await addPendingSurvey(surveyRef.id);
+      }
+
+      return surveyRef.id;
+    } catch (e) {
+      print('Error creating survey: $e');
+      rethrow;
+    }
+  }
+
+  /// Upload pending images from the temporary folder to Firebase Storage.
+  Future<void> uploadPendingImages() async {
+    final tempDir = await getTemporaryDirectory();
+    final pendingRoot = Directory(p.join(tempDir.path, 'surveyPending'));
+    if (!await pendingRoot.exists()) return;
+
+    final surveyDirs = pendingRoot.listSync().whereType<Directory>();
+    for (final dir in surveyDirs) {
+      final surveyId = p.basename(dir.path);
+      final files = dir.listSync().whereType<File>();
+      final surveyRef = FirebaseFirestore.instance.collection('surveys').doc(surveyId);
+
+      for (final file in files) {
+        final fileName = p.basename(file.path);
+        final match = RegExp(r'room_(.+)\.jpg').firstMatch(fileName);
+        final roomNumber = match != null ? match.group(1) ?? '' : '';
+        final storagePath = 'surveyImages/$surveyId/$fileName';
+        try {
+          final snapshot = await FirebaseStorage.instance.ref(storagePath).putFile(file);
+          final downloadUrl = await snapshot.ref.getDownloadURL();
+          await surveyRef.collection('photos').add({
+            'roomNumber': roomNumber,
+            'downloadUrl': downloadUrl,
+            'fileName': fileName,
+            'timestamp': FieldValue.serverTimestamp(),
+          });
+          await file.delete();
+        } catch (e) {
+          print('Error uploading $fileName: $e');
+        }
+      }
+
+      if ((await dir.list().toList()).isEmpty) {
+        await dir.delete(recursive: true);
+      }
+
+      await removePendingSurvey(surveyId);
+    }
+  }
+
+  /// SharedPreferences helpers for pending survey IDs
+  Future<void> addPendingSurvey(String surveyId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList('pendingSurveys') ?? <String>[];
+    if (!list.contains(surveyId)) {
+      list.add(surveyId);
+      await prefs.setStringList('pendingSurveys', list);
+    }
+  }
+
+  Future<void> removePendingSurvey(String surveyId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList('pendingSurveys') ?? <String>[];
+    list.remove(surveyId);
+    await prefs.setStringList('pendingSurveys', list);
+  }
+
+  Future<List<String>> getPendingSurveys() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList('pendingSurveys') ?? <String>[];
+  }
+
+  /// Clear offline Firestore cache and temporary images.
+  Future<void> clearOfflineData() async {
+    try {
+      await FirebaseFirestore.instance.clearPersistence();
+    } catch (_) {
+      // ignore
+    }
+    final tempDir = await getTemporaryDirectory();
+    final pendingRoot = Directory(p.join(tempDir.path, 'surveyPending'));
+    if (await pendingRoot.exists()) {
+      await pendingRoot.delete(recursive: true);
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('pendingSurveys');
+  }
+
+  /// Fetch survey report from Firestore.
+  Future<SurveyReport> fetchSurveyReport(String surveyId) async {
+    final surveyRef = FirebaseFirestore.instance.collection('surveys').doc(surveyId);
+    final doc = await surveyRef.get();
+    final header = SurveyHeader.fromMap(doc.data()!);
+
+    final measurementsSnap = await surveyRef.collection('measurements').orderBy('building').get();
+    final visualsSnap = await surveyRef.collection('visualAssessments').orderBy('building').get();
+    final photosSnap = await surveyRef.collection('photos').get();
+
+    final measurements = measurementsSnap.docs.map((d) => Measurement.fromMap(d.data())).toList();
+    final visuals = visualsSnap.docs.map((d) => VisualAssessment.fromMap(d.data())).toList();
+    final photos = photosSnap.docs.map((d) => PhotoMetadata.fromMap(d.data())).toList();
+
+    return SurveyReport(
+      header: header,
+      measurements: measurements,
+      visuals: visuals,
+      photos: photos,
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,9 @@ dependencies:
   flutter_email_sender: ^5.0.2
   permission_handler: ^8.1.6
   firebase_core: ^2.24.0
+  cloud_firestore: ^4.13.0
+  firebase_storage: ^11.2.6
+  connectivity_plus: ^4.0.2
   sqflite: ^2.0.0+3
   uuid: ^4.2.2
   share_plus: ^7.2.1


### PR DESCRIPTION
## Summary
- switch to Firestore offline setup
- add models for survey header, measurement, visual assessment and photos
- implement SurveyService for create, upload, sync and report
- integrate service into main and configure cache
- update dependencies for Firestore, Storage and connectivity

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a63d459883229d8f4819c438384b