### PR TITLE
Remove redundant main from ExistingSurveyScreen

### DIFF
--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -11,17 +11,6 @@ import 'package:iaqapp/database_helper.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:syncfusion_flutter_xlsio/xlsio.dart' hide Column;
 
-
-    Directory directory = Directory('path');
-
-void main() async {
-  directory = await getApplicationDocumentsDirectory();
-  
-  runApp(const MaterialApp(
-    home: ExistingSurveyScreen(),
-  ));
-}
-
 class ExistingSurveyScreen extends StatefulWidget {
   const ExistingSurveyScreen({Key? key}) : super(key: key);
 


### PR DESCRIPTION
## Summary
- delete old `main()` runner for `ExistingSurveyScreen`
- remove unused `Directory directory` declaration

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2ccddb48322b302538f0ec3ada2