### PR TITLE
Ensure user info dialog check on HomeScreen init

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,12 +46,24 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
 
   @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Retrieve dialog status on initialization
+    context.read<UserInfoDialogStatus>().getUserInfoDialogStatus();
+  }
+
+  @override
   Widget build(BuildContext context) {
-     final userInfoDialogStatus = context.watch<UserInfoDialogStatus>();
+    final userInfoDialogStatus = context.watch<UserInfoDialogStatus>();
 
     if (userInfoDialogStatus.shouldShowDialog) {
       _showEnterUserInfoDialog(context);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,16 +7,42 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:iaqapp/main.dart';
 
 void main() {
   testWidgets('HomeScreen shows Create New Survey button',
       (WidgetTester tester) async {
-    // Build HomeScreen within a MaterialApp and trigger a frame.
-    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => UserInfoDialogStatus(),
+        child: const MaterialApp(home: HomeScreen()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
 
     // Verify that the Create New Survey button is present.
     expect(find.text('Create New Survey'), findsOneWidget);
+  });
+
+  testWidgets('Alert dialog shown when First Name is missing',
+      (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => UserInfoDialogStatus(),
+        child: const MaterialApp(home: HomeScreen()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Please enter user information.'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- make `HomeScreen` a `StatefulWidget`
- query `UserInfoDialogStatus` in `initState`
- update widget tests and add a test to verify the alert dialog shows when no first name is stored

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f4c462288322a6a99bc404c1c797