### PR TITLE
Add google_api_headers dependency

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -305,13 +305,13 @@ packages:
     source: sdk
     version: "0.0.0"
   google_api_headers:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: google_api_headers
-      sha256: b27a55935d5c51cedda8a925f5df8388cc327c94a47fef5a4335e8707e089878
+      sha256: e3032f6fc3907e6ddcd0af13020b14252e828d6b835caac83c254ce768129f1c
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "4.5.1"
   google_maps_webservice:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   share_plus: ^7.2.1
   googleapis: ^12.0.0
   googleapis_auth:  ^1.4.1
+  google_api_headers: ^4.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- declare `google_api_headers` dependency in `pubspec.yaml`
- update `pubspec.lock`

## Testing
- `flutter pub get` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841f7fc0ee0832299c92c6627cee470