### PR TITLE
Replace deprecated google places package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -302,14 +302,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.0"
-  flutter_google_places:
-    dependency: "direct main"
-    description:
-      name: flutter_google_places
-      sha256: e9fb23ceacdc7359aa759627550146f7fd3ae6c067d16f39f3c50d8feebf4809
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -400,6 +392,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.20-nullsafety.5"
+  google_places_flutter:
+    dependency: "direct main"
+    description:
+      name: google_places_flutter
+      sha256: 5048f8c3e97dcb8ecfbf478bc336fefd8c4f9b903bfabcd3839c4b17eb8724eb
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   googleapis:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   easy_form_kit: ^4.1.0
   flutter_secure_storage: ^8.0.0
-  flutter_google_places: ^0.3.0
+  google_places_flutter: ^2.1.0
   intl: ^0.18.1
   shared_preferences: ^2.2.0
   csv: ^5.0.2


### PR DESCRIPTION
## Summary
- replace `flutter_google_places` with `google_places_flutter`
- update lockfile

## Testing
- `bash /tmp/check_deprec_new.sh`


------
https://chatgpt.com/codex/tasks/task_e_684303db40908322ae9be2244e922b52