### PR TITLE
Fix shareFiles to use Share.shareXFiles

### DIFF
--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -283,7 +283,8 @@ Future<void> shareFiles(String siteName, DateTime date, List<String> attachmentP
   String message = "Hello,\n\nHere are the IAQ and Visual Assessment Files for $siteName recorded on ${DateFormat('MM-dd-yyyy').format(date)} created using IAQuick.\n\nPlease review the files before submitting them.\n\nThank you,\nIAQuick";
 
   try {
-    await Share.shareFiles(attachmentPaths, text: message);
+    final files = attachmentPaths.map((p) => XFile(p)).toList();
+    await Share.shareXFiles(files, text: message);
   } catch (e) {
     // Handle error or inform the user
     print('Error sharing files: $e');


### PR DESCRIPTION
## Summary
- update `shareFiles` to share `XFile` attachments with `Share.shareXFiles`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432a86771c832291a4803079d00eb9