### PR TITLE
Fix floorNumber type issue

### DIFF
--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -501,7 +501,7 @@ Future<File> createVisualExcelFile(
         TextCellValue(va.building));
     printSheet.updateCell(
         CellIndex.indexByColumnRow(columnIndex: 1, rowIndex: rowIndex),
-        TextCellValue(va.floorNumber));
+        TextCellValue(va.floorNumber?.toString() ?? ''));
     printSheet.updateCell(
         CellIndex.indexByColumnRow(columnIndex: 2, rowIndex: rowIndex),
         TextCellValue(va.roomNumber));


### PR DESCRIPTION
## Summary
- ensure `floorNumber` is string when populating Excel cell

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435696232c83229ebfebc1f70ea091