### PR TITLE
Update Firebase init and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,28 @@
 IAQuick application for indoor air quality (IAQ) assessments and report creation. Designed to drastically improve the workflow and efficiency of indoor air quality assessments by 85+%
 
 Learn more at [sohum1094.github.io](url)
+
+## Firebase Setup
+
+1. **Install the FlutterFire CLI**
+
+   ```bash
+   dart pub global activate flutterfire_cli
+   ```
+
+2. **Configure Firebase for this project**
+
+   Run the following command in the project root and follow the prompts to select your Firebase project:
+
+   ```bash
+   flutterfire configure
+   ```
+
+   This will generate `lib/firebase_options.dart` containing your project's configuration.
+
+3. **Platform configuration files**
+
+   - Place your Android `google-services.json` file in `android/app/`.
+   - Place your iOS `GoogleService-Info.plist` file in `ios/Runner/`.
+
+After the configuration files are in place, the app can initialize Firebase using the generated options.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'existing_survey_screen.dart';
 import 'user_info/user_initial_info.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
 import 'survey_service.dart';
 
 final SurveyService surveyService = SurveyService();
@@ -13,7 +14,9 @@ final SurveyService surveyService = SurveyService();
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   await SurveyService.configureFirestoreCache();
   surveyService.startConnectivityListener();
   runApp(


### PR DESCRIPTION
## Summary
- document how to setup Firebase using the FlutterFire CLI
- initialize Firebase in `main.dart` with generated options

## Testing
- `flutter test` *(fails: command not found)*
- `flutterfire configure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d7670d1083229662645dac4abb05