### PR TITLE
Fix navigation after closing user info dialog

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:provider/provider.dart';
 import 'package:flutter/material.dart';
+import 'dart:async';
 import 'package:iaqapp/new_survey/new_survey_start.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'existing_survey_screen.dart';
@@ -184,13 +185,13 @@ class _HomeScreenState extends State<HomeScreen> {
               child: const Text('OK'),
               onPressed: () {
                 Navigator.of(context).pop();
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (BuildContext context) {
-                      return const UserInitialInfo();
-                    },
-                  ),
-                );
+                Future.microtask(() {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const UserInitialInfo(),
+                    ),
+                  );
+                });
               },
             ),
           ],


### PR DESCRIPTION
## Summary
- add `dart:async` import
- close the user info dialog then navigate in a microtask

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846524dbd908322bff42efa5a95d4b8