### PR TITLE
Fix user info dialog scheduling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,17 +61,23 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
     // Retrieve dialog status on initialization
-    context.read<UserInfoDialogStatus>().getUserInfoDialogStatus();
+    context
+        .read<UserInfoDialogStatus>()
+        .getUserInfoDialogStatus()
+        .then((_) {
+      if (mounted &&
+          context.read<UserInfoDialogStatus>().shouldShowDialog) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            _showEnterUserInfoDialog(context);
+          }
+        });
+      }
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    final userInfoDialogStatus = context.watch<UserInfoDialogStatus>();
-
-    if (userInfoDialogStatus.shouldShowDialog) {
-      _showEnterUserInfoDialog(context);
-    }
-
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(


### PR DESCRIPTION
## Summary
- show the user information dialog only after `getUserInfoDialogStatus` finishes
- remove dialog check from `HomeScreen.build`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465243971c8322ac6db9325cc754f9