### PR TITLE
Fix room readings form losing state

### DIFF
--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -42,18 +42,24 @@ import 'package:iaqapp/survey_service.dart';
 int roomCount = 0;
 List<RoomReading> roomReadings = [];
 
-class RoomReadingsFormScreen extends StatelessWidget {
+class RoomReadingsFormScreen extends StatefulWidget {
   final SurveyInfo surveyInfo;
   final OutdoorReadings outdoorReadingsInfo;
-  RoomReadingsFormScreen(
+  const RoomReadingsFormScreen(
       {required this.surveyInfo, required this.outdoorReadingsInfo, super.key});
 
+  @override
+  State<RoomReadingsFormScreen> createState() => _RoomReadingsFormScreenState();
+}
+
+class _RoomReadingsFormScreenState extends State<RoomReadingsFormScreen> {
   final GlobalKey<RoomReadingsFormState> formKey =
       GlobalKey<RoomReadingsFormState>();
+
   @override
   Widget build(BuildContext context) {
-    print('Carbon Dioxide Readings: ${surveyInfo.carbonDioxideReadings}');
-    print('Carbon Monoxide Readings: ${surveyInfo.carbonMonoxideReadings}');
+    print('Carbon Dioxide Readings: ${widget.surveyInfo.carbonDioxideReadings}');
+    print('Carbon Monoxide Readings: ${widget.surveyInfo.carbonMonoxideReadings}');
 
 
     return Scaffold(
@@ -78,8 +84,8 @@ class RoomReadingsFormScreen extends StatelessWidget {
       ),
       body: RoomReadingsForm(
           key: formKey,
-          surveyInfo: surveyInfo,
-          outdoorReadingsInfo: outdoorReadingsInfo),
+          surveyInfo: widget.surveyInfo,
+          outdoorReadingsInfo: widget.outdoorReadingsInfo),
     );
   }
 }


### PR DESCRIPTION
## Summary
- preserve `RoomReadingsFormScreen` state by converting it to a `StatefulWidget`
- keep the form's `GlobalKey` across rebuilds and continue preventing resize when keyboard shows

## Testing
- `flutter test test/widget_test.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473d5d9a448322b1004681502a2342