### PR TITLE
Add dispose to DateTimePicker

### DIFF
--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -251,6 +251,12 @@ class _DateTimePickerState extends State<DateTimePicker> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    dateInput.dispose();
+    super.dispose();
+  }
 }
 
 class LoggedScreen extends StatelessWidget {


### PR DESCRIPTION
## Summary
- release the `dateInput` controller when `DateTimePicker` is disposed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474eca91508322b80db333674ae504