### PR TITLE
Update Visual Excel export logic

### DIFF
--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -479,16 +479,10 @@ Future<File> createVisualExcelFile(
   File templateFile = await getVisualTemplateFile();
   var excel = Excel.decodeBytes(templateFile.readAsBytesSync());
 
-  var entrySheet = excel['Entry Sheet'];
   var printSheet = excel['VA for Print'];
 
-  entrySheet.cell(CellIndex.indexByString('A2')).value =
-      TextCellValue(surveyInfo.occupancyType);
-  entrySheet.cell(CellIndex.indexByString('B2')).value =
-      DateTimeCellValue.fromDateTime(surveyInfo.date);
-  entrySheet.cell(CellIndex.indexByString('D2')).value =
-      TextCellValue(surveyInfo.siteName);
-
+  printSheet.cell(CellIndex.indexByString('A1')).value =
+      TextCellValue('${surveyInfo.siteName} Visual Assessment');
   printSheet.cell(CellIndex.indexByString('A2')).value =
       DateTimeCellValue.fromDateTime(surveyInfo.date);
   printSheet.cell(CellIndex.indexByString('A3')).value =


### PR DESCRIPTION
## Summary
- update `createVisualExcelFile` to only write to the `VA for Print` sheet
- keep the workbook structure by setting cells A1–A3 and row data for each visual

## Testing
- `flutter test` *(fails: command not found)*
- `dart format -o none lib/existing_survey_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684754b0d59c8322ba8b68d5cfaeefff