### PR TITLE
Implement survey deletion

### DIFF
--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -120,7 +120,11 @@ class ExistingSurveyScreenState extends State<ExistingSurveyScreen> {
                     child: Text('Export\nto Email'),
                   ),
                 ),
-                
+                DataColumn(
+                  label: Expanded(
+                    child: Text('Delete'),
+                  ),
+                ),
 
               ],
               rows: _buildRecentFileRows(),
@@ -161,6 +165,14 @@ class ExistingSurveyScreenState extends State<ExistingSurveyScreen> {
               elevation: 0,
             ),
             child: const Icon(Icons.email),
+          ),
+        ),
+        DataCell(
+          IconButton(
+            icon: const Icon(Icons.delete, color: Colors.red),
+            onPressed: () {
+              _confirmDeleteSurvey(surveyInfo);
+            },
           ),
         ),
       ]);
@@ -207,7 +219,12 @@ class ExistingSurveyScreenState extends State<ExistingSurveyScreen> {
                     child: Text('Export\nto Email'),
                   ),
                 ),
-                
+                DataColumn(
+                  label: Expanded(
+                    child: Text('Delete'),
+                  ),
+                ),
+
               ],
               rows: _buildSearchResultRows(searchResults),
             ),
@@ -249,8 +266,45 @@ class ExistingSurveyScreenState extends State<ExistingSurveyScreen> {
             child: const Icon(Icons.email),
           ),
         ),
+        DataCell(
+          IconButton(
+            icon: const Icon(Icons.delete, color: Colors.red),
+            onPressed: () {
+              _confirmDeleteSurvey(surveyInfo);
+            },
+          ),
+        ),
       ]);
     }).toList();
+  }
+
+  Future<void> _confirmDeleteSurvey(SurveyInfo survey) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Survey'),
+        content:
+            Text('Are you sure you want to delete "${survey.siteName}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      final service = SurveyService();
+      await service.deleteSurvey(survey.id);
+      setState(() {
+        surveyList.removeWhere((s) => s.id == survey.id);
+      });
+    }
   }
 
 }

--- a/lib/survey_service.dart
+++ b/lib/survey_service.dart
@@ -233,5 +233,29 @@ class SurveyService {
     if (!doc.exists) return null;
     return OutdoorReadings.fromMap(doc.data()!);
   }
+
+  /// Delete a survey and its subcollections from Firestore.
+  Future<void> deleteSurvey(String surveyId) async {
+    final surveyRef =
+        FirebaseFirestore.instance.collection('surveys').doc(surveyId);
+
+    final roomSnap = await surveyRef.collection('room_readings').get();
+    for (final doc in roomSnap.docs) {
+      await doc.reference.delete();
+    }
+
+    final outdoorSnap =
+        await surveyRef.collection('outdoor_readings').get();
+    for (final doc in outdoorSnap.docs) {
+      await doc.reference.delete();
+    }
+
+    final photosSnap = await surveyRef.collection('photos').get();
+    for (final doc in photosSnap.docs) {
+      await doc.reference.delete();
+    }
+
+    await surveyRef.delete();
+  }
 }
 


### PR DESCRIPTION
## Summary
- add delete column for survey tables
- confirm deletion with dialog and remove survey on approval
- implement deleteSurvey to remove document and subcollections

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684758c91e98832298732ef4eafdc092