### PR TITLE
Use ExcelColor in style helpers

### DIFF
--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -523,19 +523,19 @@ Future<OutdoorReadings?> fetchOutdoorReadingsForSurvey(String surveyId) async {
 }
 
 CellStyle headerStyle() => CellStyle(
-      backgroundColorHex: '#4472C4',
+      backgroundColorHex: ExcelColor.fromHexString('#4472C4'),
       fontFamily: getFontFamily(FontFamily.Calibri),
       bold: true,
       fontSize: 16,
-      fontColorHex: '#FFFFFF',
+      fontColorHex: ExcelColor.fromHexString('#FFFFFF'),
       horizontalAlign: HorizontalAlign.Center,
     );
 
-CellStyle subHeaderStyle() => headerStyle().copyWith(fontSize: 12);
+CellStyle subHeaderStyle() => headerStyle().copyWith(fontSizeVal: 12);
 
 CellStyle columnHeaderStyle() => CellStyle(
       bold: true,
-      backgroundColorHex: '#D9E1F2',
+      backgroundColorHex: ExcelColor.fromHexString('#D9E1F2'),
       horizontalAlign: HorizontalAlign.Center,
     );
 


### PR DESCRIPTION
## Summary
- update Excel style helpers to use `ExcelColor.fromHexString`
- ensure `subHeaderStyle` calls `copyWith(fontSizeVal: 12)`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684837f6c6848322a0ce6814646fbe5b