### PR TITLE
Add Google sign-in and sign-up flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ The application uses the Firebase user's `displayName` to derive your initials
 when naming saved files. You can set this value when creating the account or
 later in the Firebase console.
 
+#### Google Sign‑In
+
+1. On the **Sign‑in method** tab also enable **Google**.
+2. Add your Android and iOS package names and SHA‑1 keys in the Firebase console.
+
+#### Resolving "Requests to this API ... SignInWithPassword are blocked"
+
+If you see an error similar to `Requests to this API identitytoolkit method
+google.cloud.identitytoolkit.v1.AuthenticationService.SignInWithPassword are
+blocked`, verify that the **Identity Toolkit API** (also called "Identity
+Platform") is enabled for your Google Cloud project. This API is required for
+email/password authentication.
+
 ## Offline Excel Export Example
 
 A helper script `scripts/export_to_excel.py` demonstrates how to create an IAQ Excel

--- a/lib/auth/sign_up_screen.dart
+++ b/lib/auth/sign_up_screen.dart
@@ -1,19 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import '../auth_service.dart';
-import 'sign_up_screen.dart';
 
-class SignInScreen extends StatefulWidget {
-  const SignInScreen({super.key});
+import '../auth_service.dart';
+
+class SignUpScreen extends StatefulWidget {
+  const SignUpScreen({super.key});
 
   @override
-  State<SignInScreen> createState() => _SignInScreenState();
+  State<SignUpScreen> createState() => _SignUpScreenState();
 }
 
-class _SignInScreenState extends State<SignInScreen> {
+class _SignUpScreenState extends State<SignUpScreen> {
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _displayNameController = TextEditingController();
   bool _isLoading = false;
   String? _error;
 
@@ -21,11 +22,15 @@ class _SignInScreenState extends State<SignInScreen> {
   Widget build(BuildContext context) {
     final authService = Provider.of<AuthService>(context, listen: false);
     return Scaffold(
-      appBar: AppBar(title: const Text('Sign In')),
+      appBar: AppBar(title: const Text('Create Account')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
+            TextField(
+              controller: _displayNameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
             TextField(
               controller: _emailController,
               decoration: const InputDecoration(labelText: 'Email'),
@@ -46,10 +51,12 @@ class _SignInScreenState extends State<SignInScreen> {
                         _error = null;
                       });
                       try {
-                        await authService.signIn(
+                        await authService.signUp(
                           _emailController.text.trim(),
                           _passwordController.text.trim(),
+                          displayName: _displayNameController.text.trim(),
                         );
+                        if (mounted) Navigator.pop(context);
                       } on FirebaseAuthException catch (e) {
                         setState(() {
                           _error = e.message;
@@ -64,30 +71,7 @@ class _SignInScreenState extends State<SignInScreen> {
                     },
               child: _isLoading
                   ? const CircularProgressIndicator()
-                  : const Text('Sign In'),
-            ),
-            const SizedBox(height: 10),
-            OutlinedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const SignUpScreen()),
-                );
-              },
-              child: const Text('Create Account'),
-            ),
-            const SizedBox(height: 10),
-            ElevatedButton(
-              onPressed: () async {
-                try {
-                  await authService.signInWithGoogle();
-                } on FirebaseAuthException catch (e) {
-                  setState(() {
-                    _error = e.message;
-                  });
-                }
-              },
-              child: const Text('Sign In with Google'),
+                  : const Text('Create Account'),
             ),
           ],
         ),

--- a/lib/auth_service.dart
+++ b/lib/auth_service.dart
@@ -1,7 +1,9 @@
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
+  final GoogleSignIn _googleSignIn = GoogleSignIn();
 
   Stream<User?> authStateChanges() => _auth.authStateChanges();
 
@@ -15,6 +17,22 @@ class AuthService {
       await cred.user?.updateDisplayName(displayName);
     }
     return cred;
+  }
+
+  Future<UserCredential> signInWithGoogle() async {
+    final googleUser = await _googleSignIn.signIn();
+    if (googleUser == null) {
+      throw FirebaseAuthException(
+        code: 'ERROR_ABORTED_BY_USER',
+        message: 'Sign in aborted by user',
+      );
+    }
+    final googleAuth = await googleUser.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    return _auth.signInWithCredential(credential);
   }
 
   Future<void> signOut() => _auth.signOut();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   cloud_firestore: ^5.6.8
   firebase_storage: ^12.4.6
   firebase_auth: ^4.17.4
+  google_sign_in: ^6.2.1
   connectivity_plus: ^6.1.4
   sqflite: ^2.0.0+3
   uuid: ^4.2.2

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:iaqapp/auth_service.dart';
 import 'package:iaqapp/auth/sign_in_screen.dart';
 
 void main() {
-  testWidgets('SignInScreen shows sign in button', (WidgetTester tester) async {
+  testWidgets('SignInScreen shows sign in and sign up buttons', (WidgetTester tester) async {
     await tester.pumpWidget(
       Provider<AuthService>(
         create: (_) => AuthService(),
@@ -24,5 +24,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Sign In'), findsOneWidget);
+    expect(find.text('Create Account'), findsOneWidget);
+    expect(find.text('Sign In with Google'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- support Google sign-in via firebase_auth and google_sign_in
- add sign-up screen and navigation from sign-in page
- document Google sign-in configuration and how to fix Identity Toolkit errors
- test updates for new buttons

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486d63ad98832288c68afa155667a3