### PR TITLE
Enable camera permission flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ blocked`, verify that the **Identity Toolkit API** (also called "Identity
 Platform") is enabled for your Google Cloud project. This API is required for
 email/password authentication.
 
+## Camera Permission
+
+The app captures photos as part of room readings. Grant camera access when
+prompted. On iOS add an `NSCameraUsageDescription` entry in `Info.plist`, and on
+Android declare `android.permission.CAMERA` in `AndroidManifest.xml`.
+
 ## Offline Excel Export Example
 
 A helper script `scripts/export_to_excel.py` demonstrates how to create an IAQ Excel

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.iaqapp">
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <application
+        android:label="iaqapp"
+        android:icon="@mipmap/ic_launcher">
+    </application>
+</manifest>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSCameraUsageDescription</key>
+    <string>Allow camera access to capture room images.</string>
+</dict>
+</plist>

--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -30,6 +30,7 @@
 /// - The image is saved locally.
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'dart:async';
 import 'dart:io';
 import 'package:path_provider/path_provider.dart';
@@ -151,9 +152,22 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
   }
 
   Future<void> _getImage() async {
+    final status = await Permission.camera.request();
     final imagePicker = ImagePicker();
-    final pickedImage =
-        await imagePicker.pickImage(source: ImageSource.gallery);
+    XFile? pickedImage;
+
+    if (status.isGranted) {
+      pickedImage = await imagePicker.pickImage(source: ImageSource.camera);
+    } else if (status.isDenied) {
+      pickedImage = await imagePicker.pickImage(source: ImageSource.gallery);
+    } else {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Camera permission denied')),
+        );
+      }
+      return;
+    }
 
     if (pickedImage != null) {
       setState(() {


### PR DESCRIPTION
## Summary
- handle camera permission in room readings
- document camera permission requirement
- add camera usage descriptions for iOS and Android

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ca160fd48322854cdefe334981d2