### PR TITLE
Implement offline image naming helper

### DIFF
--- a/lib/survey_service.dart
+++ b/lib/survey_service.dart
@@ -80,6 +80,27 @@ class SurveyService {
     }
   }
 
+  /// Save an image for a room locally using the new naming scheme.
+  Future<String> saveRoomImageOffline({
+    required File image,
+    required String surveyId,
+    required String building,
+    required String floor,
+    required String roomNumber,
+  }) async {
+    final tempDir = await getTemporaryDirectory();
+    final surveyDir = Directory(p.join(tempDir.path, 'surveyPending', surveyId));
+    await surveyDir.create(recursive: true);
+
+    String sanitize(String value) => value.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '');
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final fileName = '${surveyId}_${sanitize(building)}_${sanitize(floor)}_${sanitize(roomNumber)}_${timestamp}.jpg';
+    final destPath = p.join(surveyDir.path, fileName);
+    await image.copy(destPath);
+    await addPendingSurvey(surveyId);
+    return fileName;
+  }
+
   /// Upload pending images from the temporary folder to Firebase Storage.
   Future<void> uploadPendingImages() async {
     final tempDir = await getTemporaryDirectory();
@@ -94,8 +115,17 @@ class SurveyService {
 
       for (final file in files) {
         final fileName = p.basename(file.path);
-        final match = RegExp(r'room_(.+)\.jpg').firstMatch(fileName);
-        final roomNumber = match != null ? match.group(1) ?? '' : '';
+        final parts = fileName.split('_');
+        String roomNumber = '';
+        DateTime? timestamp;
+        if (parts.length >= 5) {
+          roomNumber = parts[3];
+          final tsStr = parts[4].split('.').first;
+          final tsInt = int.tryParse(tsStr);
+          if (tsInt != null) {
+            timestamp = DateTime.fromMillisecondsSinceEpoch(tsInt);
+          }
+        }
         final storagePath = 'surveyImages/$surveyId/$fileName';
         try {
           final snapshot = await FirebaseStorage.instance.ref(storagePath).putFile(file);
@@ -104,7 +134,7 @@ class SurveyService {
             'roomNumber': roomNumber,
             'downloadUrl': downloadUrl,
             'fileName': fileName,
-            'timestamp': FieldValue.serverTimestamp(),
+            'timestamp': timestamp,
           });
           await file.delete();
         } catch (e) {


### PR DESCRIPTION
## Summary
- add helper to save room images offline with `<surveyId>_<building>_<floor>_<room>_<timestamp>.jpg` names
- parse this filename in `uploadPendingImages` when uploading to Firebase

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ca1db9e48322af0fe78b672177d8