### PR TITLE
Fix navigation on outdoor reading save

### DIFF
--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -323,7 +323,6 @@ class LoggedScreen extends StatelessWidget {
               TextButton(
                 child: const Text('Next'),
                 onPressed: () async {
-                  Navigator.of(context).pop();
                   final reading = await Navigator.push(
                     context,
                     MaterialPageRoute(
@@ -335,7 +334,7 @@ class LoggedScreen extends StatelessWidget {
                     roomReadings.add(reading);
                   }
                   if (context.mounted) {
-                    Navigator.push(
+                    Navigator.pushReplacement(
                       context,
                       MaterialPageRoute(
                           builder: (context) =>


### PR DESCRIPTION
## Summary
- navigate to outdoor readings without popping intermediate screen
- push room readings screen after saving via pushReplacement

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bae5d181883229decf782f1eac867