### PR TITLE
Fix OutdoorReadingsScreen navigation

### DIFF
--- a/lib/new_survey/outdoor_readings_screen.dart
+++ b/lib/new_survey/outdoor_readings_screen.dart
@@ -26,28 +26,26 @@ class _OutdoorReadingsScreenState extends State<OutdoorReadingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        resizeToAvoidBottomInset: false,
-        appBar: AppBar(
-          title: Text('${widget.surveyInfo.siteName} Outdoor Readings'),
-          centerTitle: true,
-          backgroundColor: Colors.blueGrey,
-          leading: BackButton(
-            onPressed: () => Navigator.pop(context),
-          ),
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(
+        title: Text('${widget.surveyInfo.siteName} Outdoor Readings'),
+        centerTitle: true,
+        backgroundColor: Colors.blueGrey,
+        leading: BackButton(
+          onPressed: () => Navigator.pop(context),
         ),
-        body: Center(
-          child: SizedBox(
-            width: MediaQuery.of(context).size.width * .9,
-            child: Column(
-              children: [
-                Expanded(
-                  flex: 1,
-                  child: outdoorReadingsInfoForm(context, widget.surveyInfo),
-                ),
-              ],
-            ),
+      ),
+      body: Center(
+        child: SizedBox(
+          width: MediaQuery.of(context).size.width * .9,
+          child: Column(
+            children: [
+              Expanded(
+                flex: 1,
+                child: outdoorReadingsInfoForm(context, widget.surveyInfo),
+              ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- return a `Scaffold` instead of a nested `MaterialApp` in `OutdoorReadingsScreen`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bb00bf7c883229616a14b179c2e3f