### PR TITLE
Fix outdoor reading toggle during first room entry

### DIFF
--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -398,18 +398,20 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                   CheckboxListTile(
                     title: const Text('Outdoor Reading'),
                     value: isOutdoorReading,
-                    onChanged: (value) {
-                      setState(() {
-                        isOutdoorReading = value ?? false;
-                        clearFields();
-                        if (isOutdoorReading) {
-                          dropdownModel.building = 'Outdoor';
-                          dropdownModel.floor = '-';
-                          roomNumberTextController.text = '-';
-                          primaryUseTextController.text = '-';
-                        }
-                      });
-                    },
+                    onChanged: roomReadings.isEmpty
+                        ? null
+                        : (value) {
+                            setState(() {
+                              isOutdoorReading = value ?? false;
+                              clearFields();
+                              if (isOutdoorReading) {
+                                dropdownModel.building = 'Outdoor';
+                                dropdownModel.floor = '-';
+                                roomNumberTextController.text = '-';
+                                primaryUseTextController.text = '-';
+                              }
+                            });
+                          },
                   ),
                   Row(
                     children: [


### PR DESCRIPTION
## Summary
- ensure first room remains an outdoor reading by disabling the checkbox until at least one room is saved

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4a0f50108322a1eb8ff414421e28