### PR TITLE
Fix connectivity uploads and enhance PDF photo export

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,7 @@ void main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   await SurveyService.configureFirestoreCache();
-  surveyService.startConnectivityListener();
+  await surveyService.startConnectivityListener();
   runApp(
     Provider<AuthService>(
       create: (_) => AuthService(),

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -129,23 +129,41 @@ class VisualAssessment {
 
 class PhotoMetadata {
   final String roomNumber;
+  final String building;
+  final String floor;
   final String downloadUrl;
   final String fileName;
   final DateTime? timestamp;
 
   PhotoMetadata({
     required this.roomNumber,
+    required this.building,
+    required this.floor,
     required this.downloadUrl,
     required this.fileName,
     this.timestamp,
   });
 
-  factory PhotoMetadata.fromMap(Map<String, dynamic> map) => PhotoMetadata(
-        roomNumber: map['roomNumber'] ?? '',
-        downloadUrl: map['downloadUrl'] ?? '',
-        fileName: map['fileName'] ?? '',
-        timestamp: (map['timestamp'] as Timestamp?)?.toDate(),
-      );
+  factory PhotoMetadata.fromMap(Map<String, dynamic> map) {
+    String building = map['building'] ?? '';
+    String floor = map['floor'] ?? '';
+    final fileName = map['fileName'] ?? '';
+    if (building.isEmpty || floor.isEmpty) {
+      final parts = fileName.split('_');
+      if (parts.length >= 5) {
+        building = parts[1];
+        floor = parts[2];
+      }
+    }
+    return PhotoMetadata(
+      roomNumber: map['roomNumber'] ?? '',
+      building: building,
+      floor: floor,
+      downloadUrl: map['downloadUrl'] ?? '',
+      fileName: fileName,
+      timestamp: (map['timestamp'] as Timestamp?)?.toDate(),
+    );
+  }
 }
 
 class SurveyReport {


### PR DESCRIPTION
## Summary
- ensure connectivity listener uploads pending images on startup
- await connectivity initialization in main
- include building and floor info when uploading photos
- extend `PhotoMetadata` model with building and floor parsing
- improve PDF export to show images with room-specific numbering and inspector initials

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db04641688322ac3e737492f8c0df