### PR TITLE
Fix survey timestamp handling

### DIFF
--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -144,7 +144,7 @@ class ExistingSurveyScreenState extends State<ExistingSurveyScreen> {
   // Extract date
       return DataRow(cells: [
         DataCell(Text(surveyInfo.siteName),),
-        DataCell(Text(DateFormat('MM/dd hh:mm a').format(surveyInfo.date)),),
+        DataCell(Text(DateFormat('MM/dd hh:mm a').format(_withCurrentTimeIfMissing(surveyInfo.date))),),
         DataCell(
           ElevatedButton(
             onPressed: () async {
@@ -258,7 +258,7 @@ class ExistingSurveyScreenState extends State<ExistingSurveyScreen> {
           Text(surveyInfo.siteName), // Display site name
         ),
         DataCell(
-          Text(DateFormat('MM/dd hh:mm a').format(surveyInfo.date)), // Display date
+          Text(DateFormat('MM/dd hh:mm a').format(_withCurrentTimeIfMissing(surveyInfo.date))), // Display date
         ),
         DataCell(
           ElevatedButton(
@@ -411,7 +411,8 @@ Future<File> createIAQExcelFile(
 
   sheet.merge(CellIndex.indexByString('A2'), CellIndex.indexByString('${lastCol}2'));
   sheet.cell(CellIndex.indexByString('A2')).value =
-      TextCellValue(DateFormat('yyyy-MM-dd HH:mm').format(surveyInfo.date));
+      TextCellValue(
+          DateFormat('yyyy-MM-dd HH:mm').format(_withCurrentTimeIfMissing(surveyInfo.date)));
   sheet.cell(CellIndex.indexByString('A2')).cellStyle = subHeaderStyle();
 
   sheet.merge(CellIndex.indexByString('A3'), CellIndex.indexByString('${lastCol}3'));
@@ -683,7 +684,8 @@ Future<File> createVisualExcelFile(
   sheet.cell(CellIndex.indexByString('A1')).cellStyle = headerStyle();
 
   sheet.merge(CellIndex.indexByString('A2'), CellIndex.indexByString('E2'));
-  sheet.cell(CellIndex.indexByString('A2')).value = TextCellValue(DateFormat('yyyy-MM-dd HH:mm').format(surveyInfo.date));
+  sheet.cell(CellIndex.indexByString('A2')).value = TextCellValue(
+      DateFormat('yyyy-MM-dd HH:mm').format(_withCurrentTimeIfMissing(surveyInfo.date)));
   sheet.cell(CellIndex.indexByString('A2')).cellStyle = subHeaderStyle();
 
   sheet.merge(CellIndex.indexByString('A3'), CellIndex.indexByString('E3'));
@@ -791,14 +793,16 @@ CellStyle columnHeaderStyle() => CellStyle(
       horizontalAlign: HorizontalAlign.Center,
     );
 
-String formatDate(DateTime date) {
-  // If the stored survey date lacks a time component, use the current
-  // time so that exported filenames remain unique.
+DateTime _withCurrentTimeIfMissing(DateTime date) {
   if (date.hour == 0 && date.minute == 0 && date.second == 0) {
     final now = DateTime.now();
-    date = DateTime(date.year, date.month, date.day, now.hour, now.minute);
+    return DateTime(date.year, date.month, date.day, now.hour, now.minute);
   }
-  return DateFormat('yyyyMMdd_HHmm').format(date);
+  return date;
+}
+
+String formatDate(DateTime date) {
+  return DateFormat('yyyyMMdd_HHmm').format(_withCurrentTimeIfMissing(date));
 }
 
 Future<Uint8List> _downloadImageBytes(String url) async {

--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -276,8 +276,16 @@ class _DateTimePickerState extends State<DateTimePicker> {
           lastDate: DateTime(2101),
         );
         if (pickedDate != null) {
-          // Update the model
-          widget.model.date = pickedDate;
+          // Preserve the selected date but attach the current time so
+          // report timestamps reflect the moment the survey was created.
+          final now = DateTime.now();
+          widget.model.date = DateTime(
+            pickedDate.year,
+            pickedDate.month,
+            pickedDate.day,
+            now.hour,
+            now.minute,
+          );
           // Set the date in the controller
           dateInput.text = DateFormat('MM-dd-yyyy').format(pickedDate);
         }


### PR DESCRIPTION
## Summary
- store current time when selecting the survey date
- make exported filenames, headers and list views use non-midnight times

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68538f0d994883228a8085357c5e55fd