### PR TITLE
Collect project number for survey exports

### DIFF
--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -20,7 +20,7 @@ class DatabaseHelper {
 
     return await openDatabase(
       path,
-      version: 2,
+      version: 3,
       onCreate: _createDB,
       onUpgrade: _upgradeDB,
     );
@@ -31,6 +31,7 @@ class DatabaseHelper {
     CREATE TABLE survey_info (
       ID TEXT PRIMARY KEY,
       siteName TEXT,
+      projectNumber TEXT,
       date TEXT,
       address TEXT,
       occupancyType TEXT,
@@ -72,6 +73,10 @@ class DatabaseHelper {
       await db.execute(
           "ALTER TABLE room_readings ADD COLUMN timestamp TEXT");
     }
+    if (oldVersion < 3) {
+      await db.execute(
+          "ALTER TABLE survey_info ADD COLUMN projectNumber TEXT");
+    }
   }
 
 
@@ -87,7 +92,7 @@ class DatabaseHelper {
     final db = await instance.database;
     final maps = await db.query(
       'survey_info',
-      columns: ['id', 'siteName', 'date', 'address', 'occupancyType', 'carbonDioxideReadings', 'carbonMonoxideReadings', 'vocs', 'pm25', 'pm10'],
+      columns: ['id', 'siteName', 'projectNumber', 'date', 'address', 'occupancyType', 'carbonDioxideReadings', 'carbonMonoxideReadings', 'vocs', 'pm25', 'pm10'],
       where: 'id = ?',
       whereArgs: [id],
     );

--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -562,9 +562,10 @@ Future<File> createIAQExcelFile(
   }
 
   final bytes = wb.encode();
+  final sanitizedProject = sanitizeFileNamePart(surveyInfo.projectNumber);
   final filePath = path.join(
       directory.path,
-      'SPC_${surveyInfo.siteName.replaceAll(' ', '_')}_{ProjectNumber}_IAQ_${formatDate(surveyInfo.date)}_${getInspector()}.xlsx');
+      'SPC_${surveyInfo.siteName.replaceAll(' ', '_')}_${sanitizedProject}_IAQ_${formatDate(surveyInfo.date)}_${getInspector()}.xlsx');
   final file = File(filePath)..writeAsBytesSync(bytes!);
   return file;
 }
@@ -651,9 +652,10 @@ Future<File> createPhotoPdf(
   }
 
   final directory = await getApplicationDocumentsDirectory();
+  final sanitizedProject = sanitizeFileNamePart(info.projectNumber);
   final filePath = path.join(
     directory.path,
-    'SPC_${info.siteName.replaceAll(' ', '_')}_{ProjectNumber}_Photos_${formatDate(info.date)}_$inspector.pdf',
+    'SPC_${info.siteName.replaceAll(' ', '_')}_${sanitizedProject}_Photos_${formatDate(info.date)}_$inspector.pdf',
   );
   final file = File(filePath);
   await file.writeAsBytes(await pdf.save());
@@ -664,6 +666,7 @@ Future<File> createVisualExcelFile(
     SurveyInfo surveyInfo, List<VisualAssessment> visuals,
     [List<RoomReading>? roomReadings]) async {
   final directory = await getApplicationDocumentsDirectory();
+  final sanitizedProject = sanitizeFileNamePart(surveyInfo.projectNumber);
   final wb = Excel.createExcel();
   final sheet = wb['Visual'];
   wb.delete('Sheet1');
@@ -748,7 +751,7 @@ Future<File> createVisualExcelFile(
   final bytes = wb.encode();
   final filePath = path.join(
       directory.path,
-      'SPC_${surveyInfo.siteName.replaceAll(' ', '_')}_{projectNumber}_Visual_${formatDate(surveyInfo.date)}_${getInspector()}.xlsx');
+      'SPC_${surveyInfo.siteName.replaceAll(' ', '_')}_${sanitizedProject}_Visual_${formatDate(surveyInfo.date)}_${getInspector()}.xlsx');
   final file = File(filePath)..writeAsBytesSync(bytes!);
   return file;
 }
@@ -828,3 +831,7 @@ String getInspector() {
 }
 
 
+
+String sanitizeFileNamePart(String input) {
+  return input.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_');
+}

--- a/lib/models/survey_info.dart
+++ b/lib/models/survey_info.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 class SurveyInfo {
   String id; // id is now a non-nullable String
   String siteName;
+  String projectNumber;
   DateTime date;
   String address;
   String occupancyType;
@@ -17,6 +18,7 @@ class SurveyInfo {
   SurveyInfo()
       : id = const Uuid().v4(), // Generate a new UUID
         siteName = "",
+        projectNumber = "",
         date = DateTime.parse("19700101"),
         address = "",
         occupancyType = "",
@@ -30,6 +32,7 @@ class SurveyInfo {
   SurveyInfo.parameterized({
     String? id, // Accept an existing ID as nullable
     required this.siteName,
+    this.projectNumber = '',
     required this.date,
     required this.address,
     required this.occupancyType,
@@ -44,6 +47,7 @@ class SurveyInfo {
     final Map<String,dynamic> data = {
       'id' : id,
       'siteName': siteName,
+      'projectNumber': projectNumber,
       'date': date.toIso8601String(),
       'address': address,
       'occupancyType': occupancyType,
@@ -59,6 +63,7 @@ class SurveyInfo {
   SurveyInfo.fromMap(Map<String, dynamic> map)
     : id = map['id'] ?? const Uuid().v4(), // Assign an existing ID or generate a new one
       siteName = map['siteName'] ?? "",
+      projectNumber = map['projectNumber'] ?? "",
       date = DateTime.tryParse(map['date']) ?? DateTime.parse("1970-01-01"),
       address = map['address'] ?? "",
       occupancyType = map['occupancyType'] ?? "",

--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -90,6 +90,7 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
       key: _initialSurveyInfoKey,
       onSave: (values, form) async {
         if (values['siteName'].isEmpty ||
+            values['projectNumber'].isEmpty ||
             values['siteAddress'].isEmpty ||
             !form.validate()) {
           showDialog<String>(
@@ -112,6 +113,7 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
       },
       onSaved: (response, values, form) {
         if (values['siteName'].isNotEmpty &&
+            values['projectNumber'].isNotEmpty &&
             values['siteAddress'].isNotEmpty &&
             form.validate()) {
           Navigator.of(context).push(
@@ -132,6 +134,7 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
               child: Column(
                 children: [
                   siteNameTextFormField(context, model),
+                  projectNumberTextFormField(context, model),
                   addressTextFormField(
                       context, model, _addressController, _addressFocusNode),
                   DateTimePicker(model: model),
@@ -188,6 +191,33 @@ EasyTextFormField siteNameTextFormField(
     onSaved: (tempSiteName) {
       if (tempSiteName != null) {
         model.siteName = tempSiteName;
+      }
+    },
+  );
+}
+
+EasyTextFormField projectNumberTextFormField(
+    BuildContext context, SurveyInfo model) {
+  return EasyTextFormField(
+    initialValue: '',
+    name: 'projectNumber',
+    autovalidateMode: EasyAutovalidateMode.always,
+    validator: (value, [values]) {
+      if (value == null) {
+        return null;
+      } else if (value.isNotEmpty &&
+          !RegExp(r'^[a-zA-Z0-9 _-]+$').hasMatch(value)) {
+        return "Enter Correct Project #";
+      } else {
+        return null;
+      }
+    },
+    decoration: const InputDecoration(
+      labelText: 'Project #*',
+    ),
+    onSaved: (tempProjectNumber) {
+      if (tempProjectNumber != null) {
+        model.projectNumber = tempProjectNumber;
       }
     },
   );


### PR DESCRIPTION
## Summary
- capture project number when starting a survey
- store project number in the survey info model and database
- include project number in exported Excel file names

## Testing
- `apt-get install -y ed`
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542fa8af748322b400a331fcf4b065