### PR TITLE
Fix edit screen optional fields

### DIFF
--- a/lib/new_survey/edit_room_reading.dart
+++ b/lib/new_survey/edit_room_reading.dart
@@ -8,7 +8,13 @@ import 'dart:io';
 class EditRoomReading extends StatefulWidget {
   final int index;
   final RoomReading roomReading;
-  const EditRoomReading({super.key, required this.index, required this.roomReading});
+  final SurveyInfo surveyInfo;
+  const EditRoomReading({
+    super.key,
+    required this.index,
+    required this.roomReading,
+    required this.surveyInfo,
+  });
 
   @override
   State<EditRoomReading> createState() => _EditRoomReadingState();
@@ -156,31 +162,41 @@ class _EditRoomReadingState extends State<EditRoomReading> {
                 keyboardType: const TextInputType.numberWithOptions(decimal: true),
                 decoration: const InputDecoration(labelText: 'Relative Humidity'),
               ),
-              TextFormField(
-                controller: co2Ctrl,
-                keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                decoration: const InputDecoration(labelText: 'CO₂'),
-              ),
-              TextFormField(
-                controller: coCtrl,
-                keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                decoration: const InputDecoration(labelText: 'CO'),
-              ),
-              TextFormField(
-                controller: vocsCtrl,
-                keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                decoration: const InputDecoration(labelText: 'VOCs'),
-              ),
-              TextFormField(
-                controller: pm25Ctrl,
-                keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                decoration: const InputDecoration(labelText: 'PM2.5'),
-              ),
-              TextFormField(
-                controller: pm10Ctrl,
-                keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                decoration: const InputDecoration(labelText: 'PM10'),
-              ),
+              if (widget.surveyInfo.carbonDioxideReadings)
+                TextFormField(
+                  controller: co2Ctrl,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'CO₂'),
+                ),
+              if (widget.surveyInfo.carbonMonoxideReadings)
+                TextFormField(
+                  controller: coCtrl,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'CO'),
+                ),
+              if (widget.surveyInfo.vocs)
+                TextFormField(
+                  controller: vocsCtrl,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'VOCs'),
+                ),
+              if (widget.surveyInfo.pm25)
+                TextFormField(
+                  controller: pm25Ctrl,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'PM2.5'),
+                ),
+              if (widget.surveyInfo.pm10)
+                TextFormField(
+                  controller: pm10Ctrl,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'PM10'),
+                ),
               TextFormField(
                 controller: commentsCtrl,
                 decoration: const InputDecoration(labelText: 'Comments'),

--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -77,7 +77,9 @@ class _RoomReadingsFormScreenState extends State<RoomReadingsFormScreen> {
             await Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (_) => const RoomReadingsOverview(),
+                builder: (_) => RoomReadingsOverview(
+                  surveyInfo: widget.surveyInfo,
+                ),
               ),
             );
             setState(() {});

--- a/lib/new_survey/room_readings_overview.dart
+++ b/lib/new_survey/room_readings_overview.dart
@@ -4,7 +4,8 @@ import 'package:iaqapp/new_survey/room_readings.dart';
 import 'edit_room_reading.dart';
 
 class RoomReadingsOverview extends StatefulWidget {
-  const RoomReadingsOverview({super.key});
+  final SurveyInfo surveyInfo;
+  const RoomReadingsOverview({super.key, required this.surveyInfo});
 
   @override
   State<RoomReadingsOverview> createState() => _RoomReadingsOverviewState();
@@ -74,6 +75,7 @@ class _RoomReadingsOverviewState extends State<RoomReadingsOverview> {
                           builder: (_) => EditRoomReading(
                             index: listIndex,
                             roomReading: reading,
+                            surveyInfo: widget.surveyInfo,
                           ),
                         ),
                       );


### PR DESCRIPTION
## Summary
- pass SurveyInfo when navigating to room readings overview
- forward survey info to edit screen so it knows which optional readings to display
- conditionally show optional fields on edit screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a8b97ce88322882d32759d147db8