### PR TITLE
Fix logout redirection

### DIFF
--- a/lib/auth_service.dart
+++ b/lib/auth_service.dart
@@ -35,5 +35,11 @@ class AuthService {
     return _auth.signInWithCredential(credential);
   }
 
-  Future<void> signOut() => _auth.signOut();
+  Future<void> signOut() async {
+    // Sign out from Firebase as well as any linked Google account
+    await Future.wait([
+      _auth.signOut(),
+      _googleSignIn.signOut(),
+    ]);
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -89,7 +89,15 @@ class HomeScreen extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.logout),
-            onPressed: () => authService.signOut(),
+            onPressed: () async {
+              await authService.signOut();
+              if (context.mounted) {
+                Navigator.of(context).pushAndRemoveUntil(
+                  MaterialPageRoute(builder: (_) => const SignInScreen()),
+                  (route) => false,
+                );
+              }
+            },
           ),
         ],
         title: const Text('IAQuick', textScaleFactor: 1.1),


### PR DESCRIPTION
## Summary
- sign out of Google account as well as Firebase
- after logout send user to sign in screen and clear the navigation stack

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855aebef9308322b6fe4f9e4e0634ce