### PR TITLE
Fix share files error

### DIFF
--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -348,12 +348,10 @@ Future<void> shareFiles(
 
   try {
     final files = attachmentPaths.map((p) => XFile(p)).toList();
-    await SharePlus.instance.share(
-      ShareParams(
-        files: files,
-        text: message,
-        subject: '[IAQuick] Report for $siteName is ready',
-      ),
+    await Share.shareXFiles(
+      files,
+      text: message,
+      subject: '[IAQuick] Report for $siteName is ready',
     );
   } catch (e) {
     // Handle error or inform the user


### PR DESCRIPTION
## Summary
- fix Android sharing intent by using Share.shareXFiles

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856182beeb08322abe8b6f8d2be7e10