### PR TITLE
Fix docxtemplater placeholders

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -35,7 +35,8 @@ exports.generateIAQReport = functions.https.onCall(async (data, context) => {
   console.log("Rendering with:", contextData);
 
   try {
-    doc.render(contextData);
+    doc.setData(contextData);
+    doc.render();
   } catch (err) {
     console.error("Template render failed:", err);
     throw new functions.https.HttpsError(


### PR DESCRIPTION
## Summary
- fix docxtemplater usage when creating Word report

## Testing
- `node --version`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564044c77c83229ad13ff5463bfa01