### PR TITLE
Enable decimal inputs like `.5`

### DIFF
--- a/lib/new_survey/edit_room_reading.dart
+++ b/lib/new_survey/edit_room_reading.dart
@@ -3,6 +3,7 @@ import 'package:iaqapp/models/survey_info.dart';
 import 'package:iaqapp/new_survey/room_readings.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:iaqapp/utils.dart';
 import 'dart:io';
 
 class EditRoomReading extends StatefulWidget {
@@ -103,13 +104,25 @@ class _EditRoomReadingState extends State<EditRoomReading> {
       r.floorNumber = floorCtrl.text;
       r.roomNumber = roomCtrl.text;
       r.primaryUse = useCtrl.text;
-      r.temperature = double.tryParse(tempCtrl.text) ?? r.temperature;
-      r.relativeHumidity = double.tryParse(humidityCtrl.text) ?? r.relativeHumidity;
-      r.co2 = co2Ctrl.text.isNotEmpty ? double.tryParse(co2Ctrl.text) : null;
-      r.co = coCtrl.text.isNotEmpty ? double.tryParse(coCtrl.text) : null;
-      r.vocs = vocsCtrl.text.isNotEmpty ? double.tryParse(vocsCtrl.text) : null;
-      r.pm25 = pm25Ctrl.text.isNotEmpty ? double.tryParse(pm25Ctrl.text) : null;
-      r.pm10 = pm10Ctrl.text.isNotEmpty ? double.tryParse(pm10Ctrl.text) : null;
+      r.temperature =
+          parseFlexibleDouble(tempCtrl.text) ?? r.temperature;
+      r.relativeHumidity =
+          parseFlexibleDouble(humidityCtrl.text) ?? r.relativeHumidity;
+      r.co2 = co2Ctrl.text.isNotEmpty
+          ? parseFlexibleDouble(co2Ctrl.text)
+          : null;
+      r.co = coCtrl.text.isNotEmpty
+          ? parseFlexibleDouble(coCtrl.text)
+          : null;
+      r.vocs = vocsCtrl.text.isNotEmpty
+          ? parseFlexibleDouble(vocsCtrl.text)
+          : null;
+      r.pm25 = pm25Ctrl.text.isNotEmpty
+          ? parseFlexibleDouble(pm25Ctrl.text)
+          : null;
+      r.pm10 = pm10Ctrl.text.isNotEmpty
+          ? parseFlexibleDouble(pm10Ctrl.text)
+          : null;
       r.comments = commentsCtrl.text;
       r.images = List<File>.from(_imageFiles);
       roomReadings[widget.index] = r;

--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -31,6 +31,7 @@
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:iaqapp/utils.dart';
 import 'dart:async';
 import 'dart:io';
 import 'package:path_provider/path_provider.dart';
@@ -194,8 +195,8 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
     if (temperatureFocusNode.hasFocus) {
       final temperatureValue = temperatureTextController.text;
       if (temperatureValue.isNotEmpty) {
-        final temperature = double.parse(temperatureValue);
-        if (temperature > 76 || temperature < 68) {
+        final temperature = parseFlexibleDouble(temperatureValue);
+        if (temperature != null && (temperature > 76 || temperature < 68)) {
           _showConfirmValueDialog(context, 'temperature');
         }
       }
@@ -251,22 +252,24 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
             isOutdoorReading ? '-' : roomNumberTextController.text,
         primaryUse:
             isOutdoorReading ? '-' : primaryUseTextController.text,
-        temperature: double.parse(temperatureTextController.text),
-        relativeHumidity: double.parse(humiditiyTextController.text),
+        temperature:
+            parseFlexibleDouble(temperatureTextController.text) ?? 0,
+        relativeHumidity:
+            parseFlexibleDouble(humiditiyTextController.text) ?? 0,
         co2: widget.surveyInfo.carbonDioxideReadings
-            ? double.tryParse(dioxTextController.text)
+            ? parseFlexibleDouble(dioxTextController.text)
             : null,
         co: widget.surveyInfo.carbonMonoxideReadings
-            ? double.tryParse(monoxTextController.text)
+            ? parseFlexibleDouble(monoxTextController.text)
             : null,
         vocs: widget.surveyInfo.vocs
-            ? double.tryParse(vocsTextController.text)
+            ? parseFlexibleDouble(vocsTextController.text)
             : null,
         pm25: widget.surveyInfo.pm25
-            ? double.tryParse(pm25TextController.text)
+            ? parseFlexibleDouble(pm25TextController.text)
             : null,
         pm10: widget.surveyInfo.pm10
-            ? double.tryParse(pm10TextController.text)
+            ? parseFlexibleDouble(pm10TextController.text)
             : null,
         comments: commentTextController.text.isEmpty
             ? "No issues were observed."
@@ -519,7 +522,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                             bool seen = false;
 
                             if (!seen &&
-                                double.parse(humiditiyTextController.text) >
+                                (parseFlexibleDouble(
+                                        humiditiyTextController.text) ??
+                                    double.negativeInfinity) >
                                     65) {
                               seen = true;
                               _showConfirmValueDialog(
@@ -529,7 +534,10 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                           onChanged: (value) {
                             bool seen = false;
 
-                            if (!seen && (double.parse(value) > 65)) {
+                            if (!seen &&
+                                (parseFlexibleDouble(value) ??
+                                        double.negativeInfinity) >
+                                    65) {
                               seen = true;
                               _showConfirmValueDialog(
                                   context, 'relative humidity');
@@ -600,7 +608,10 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       onChanged: (value) {
                         bool seen = false;
 
-                        if (!seen && double.parse(value) > 1100) {
+                        if (!seen &&
+                            (parseFlexibleDouble(value) ??
+                                    double.negativeInfinity) >
+                                1100) {
                           seen = true;
                           _showConfirmValueDialog(context, 'Carbon Dioxide');
                         }
@@ -631,7 +642,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                         bool seen = false;
 
                         if (!seen &&
-                            double.parse(monoxTextController.text) > 10) {
+                            (parseFlexibleDouble(monoxTextController.text) ??
+                                    double.negativeInfinity) >
+                                10) {
                           seen = true;
                           _showConfirmValueDialog(context, 'Carbon Monoxide');
                         }
@@ -663,7 +676,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                         bool seen = false;
 
                         if (!seen &&
-                            double.parse(vocsTextController.text) > 3.0) {
+                            (parseFlexibleDouble(vocsTextController.text) ??
+                                    double.negativeInfinity) >
+                                3.0) {
                           seen = true;
                           _showConfirmValueDialog(context, 'VOCs');
                         }
@@ -694,7 +709,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                         bool seen = false;
 
                         if (!seen &&
-                            double.parse(pm25TextController.text) > 35) {
+                            (parseFlexibleDouble(pm25TextController.text) ??
+                                    double.negativeInfinity) >
+                                35) {
                           seen = true;
                           _showConfirmValueDialog(context, 'PM 2.5');
                         }
@@ -725,7 +742,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                         bool seen = false;
 
                         if (!seen &&
-                            double.parse(pm10TextController.text) > 150) {
+                            (parseFlexibleDouble(pm10TextController.text) ??
+                                    double.negativeInfinity) >
+                                150) {
                           seen = true;
                           _showConfirmValueDialog(context, 'PM 10');
                         }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,0 +1,17 @@
+/// Utility helper functions.
+///
+/// parseFlexibleDouble converts string representations of a number
+/// that may omit the leading zero before a decimal (e.g. `.5`) into
+/// a double value.
+///
+/// If the string is null or cannot be parsed, null is returned.
+
+double? parseFlexibleDouble(String? value) {
+  if (value == null || value.isEmpty) return null;
+  final normalized = value.startsWith('.')
+      ? '0$value'
+      : value.startsWith('-.')
+          ? value.replaceFirst('-.', '-0.')
+          : value;
+  return double.tryParse(normalized);
+}


### PR DESCRIPTION
## Summary
- add `parseFlexibleDouble` helper
- allow `.5` inputs on edit room and new room forms

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c38d20dc48322974e1795c75b1187