### PR TITLE
Add optional NO2, SO2, NO readings

### DIFF
--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -20,7 +20,7 @@ class DatabaseHelper {
 
     return await openDatabase(
       path,
-      version: 3,
+      version: 4,
       onCreate: _createDB,
       onUpgrade: _upgradeDB,
     );
@@ -39,7 +39,10 @@ class DatabaseHelper {
       carbonMonoxideReadings INTEGER,
       vocs INTEGER,
       pm25 INTEGER,
-      pm10 INTEGER
+      pm10 INTEGER,
+      no2 INTEGER,
+      so2 INTEGER,
+      no INTEGER
     )
   ''');
 
@@ -58,6 +61,9 @@ class DatabaseHelper {
       pm25 REAL,
       pm10 REAL,
       vocs REAL,
+      no2 REAL,
+      so2 REAL,
+      no REAL,
       comments TEXT,
       isOutdoor INTEGER,
       timestamp TEXT,
@@ -77,6 +83,14 @@ class DatabaseHelper {
       await db.execute(
           "ALTER TABLE survey_info ADD COLUMN projectNumber TEXT");
     }
+    if (oldVersion < 4) {
+      await db.execute("ALTER TABLE survey_info ADD COLUMN no2 INTEGER");
+      await db.execute("ALTER TABLE survey_info ADD COLUMN so2 INTEGER");
+      await db.execute("ALTER TABLE survey_info ADD COLUMN no INTEGER");
+      await db.execute("ALTER TABLE room_readings ADD COLUMN no2 REAL");
+      await db.execute("ALTER TABLE room_readings ADD COLUMN so2 REAL");
+      await db.execute("ALTER TABLE room_readings ADD COLUMN no REAL");
+    }
   }
 
 
@@ -92,7 +106,7 @@ class DatabaseHelper {
     final db = await instance.database;
     final maps = await db.query(
       'survey_info',
-      columns: ['id', 'siteName', 'projectNumber', 'date', 'address', 'occupancyType', 'carbonDioxideReadings', 'carbonMonoxideReadings', 'vocs', 'pm25', 'pm10'],
+      columns: ['id', 'siteName', 'projectNumber', 'date', 'address', 'occupancyType', 'carbonDioxideReadings', 'carbonMonoxideReadings', 'vocs', 'pm25', 'pm10', 'no2', 'so2', 'no'],
       where: 'id = ?',
       whereArgs: [id],
     );

--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -398,6 +398,15 @@ Future<File> createIAQExcelFile(
   if (surveyInfo.pm10) {
     optionalHeaders.add('PM10 (mg/m³)');
   }
+  if (surveyInfo.no2) {
+    optionalHeaders.add('NO2 (ppm)');
+  }
+  if (surveyInfo.so2) {
+    optionalHeaders.add('SO2 (ppm)');
+  }
+  if (surveyInfo.no) {
+    optionalHeaders.add('NO (ppm)');
+  }
   final headers = [...baseHeaders, ...optionalHeaders];
 
   String columnLetter(int index) {
@@ -489,6 +498,21 @@ Future<File> createIAQExcelFile(
     decimals.add(3);
     numberFormats.add(CustomNumericNumFormat(formatCode:'0.000'));
   }
+  if (surveyInfo.no2) {
+    valueAccessors.add((RoomReading r) => r.no2!);
+    decimals.add(2);
+    numberFormats.add(CustomNumericNumFormat(formatCode:'0.00'));
+  }
+  if (surveyInfo.so2) {
+    valueAccessors.add((RoomReading r) => r.so2!);
+    decimals.add(2);
+    numberFormats.add(CustomNumericNumFormat(formatCode:'0.00'));
+  }
+  if (surveyInfo.no) {
+    valueAccessors.add((RoomReading r) => r.no!);
+    decimals.add(2);
+    numberFormats.add(CustomNumericNumFormat(formatCode:'0.00'));
+  }
 
   final numericDecimals = decimals.sublist(4);
   final numericFormats = numberFormats.sublist(4);
@@ -541,6 +565,18 @@ Future<File> createIAQExcelFile(
   if (surveyInfo.pm10) {
     summaryLists
         .add(indoor.where((r) => r.pm10 != null).map((r) => r.pm10!).toList());
+  }
+  if (surveyInfo.no2) {
+    summaryLists
+        .add(indoor.where((r) => r.no2 != null).map((r) => r.no2!).toList());
+  }
+  if (surveyInfo.so2) {
+    summaryLists
+        .add(indoor.where((r) => r.so2 != null).map((r) => r.so2!).toList());
+  }
+  if (surveyInfo.no) {
+    summaryLists
+        .add(indoor.where((r) => r.no != null).map((r) => r.no!).toList());
   }
 
   final summary = wb['Summary'];

--- a/lib/models/survey_info.dart
+++ b/lib/models/survey_info.dart
@@ -13,6 +13,9 @@ class SurveyInfo {
   bool vocs;
   bool pm25;
   bool pm10;
+  bool no2;
+  bool so2;
+  bool no;
 
   // Default constructor
   SurveyInfo()
@@ -26,7 +29,10 @@ class SurveyInfo {
         carbonMonoxideReadings = false,
         vocs = false,
         pm25 = false,
-        pm10 = false;
+        pm10 = false,
+        no2 = false,
+        so2 = false,
+        no = false;
 
   // Parameterized constructor
   SurveyInfo.parameterized({
@@ -41,6 +47,9 @@ class SurveyInfo {
     this.vocs = false,
     this.pm25 = false,
     this.pm10 = false,
+    this.no2 = false,
+    this.so2 = false,
+    this.no = false,
   }) : id = id ?? const Uuid().v4();
 
   Map<String, dynamic> toJson() {
@@ -56,6 +65,9 @@ class SurveyInfo {
       'vocs': vocs ? 1 : 0,
       'pm25': pm25 ? 1 : 0,
       'pm10': pm10 ? 1 : 0,
+      'no2': no2 ? 1 : 0,
+      'so2': so2 ? 1 : 0,
+      'no': no ? 1 : 0,
     };
     return data;
   }
@@ -71,7 +83,10 @@ class SurveyInfo {
       carbonMonoxideReadings = map['carbonMonoxideReadings'] == 1,
       vocs = map['vocs'] == 1,
       pm25 = map['pm25'] == 1,
-      pm10 = map['pm10'] == 1;
+      pm10 = map['pm10'] == 1,
+      no2 = map['no2'] == 1,
+      so2 = map['so2'] == 1,
+      no = map['no'] == 1;
 }
 
 class OutdoorReadings {
@@ -83,6 +98,9 @@ class OutdoorReadings {
   double? pm25; // nullable
   double? pm10; // nullable
   double? vocs; // nullable
+  double? no2; // nullable
+  double? so2; // nullable
+  double? no; // nullable
   DateTime timestamp;
 
   OutdoorReadings({
@@ -163,6 +181,9 @@ class RoomReading {
     this.pm25,
     this.pm10,
     this.vocs,
+    this.no2,
+    this.so2,
+    this.no,
     this.comments = "No issues were observed.",
     this.isOutdoor = false,
     List<File>? images,
@@ -185,6 +206,9 @@ class RoomReading {
         pm25 = map['pm25']?.toDouble(),
         pm10 = map['pm10']?.toDouble(),
         vocs = map['vocs']?.toDouble(),
+        no2 = map['no2']?.toDouble(),
+        so2 = map['so2']?.toDouble(),
+        no = map['no']?.toDouble(),
         comments = map['comments'] ?? "No issues were observed.",
         isOutdoor = map['isOutdoor'] == 1 || map['isOutdoor'] == true,
         timestamp = DateTime.tryParse(map['timestamp'].toString()) ?? DateTime.now(),
@@ -204,6 +228,9 @@ class RoomReading {
       'pm25': pm25,
       'pm10': pm10,
       'vocs': vocs,
+      'no2': no2,
+      'so2': so2,
+      'no': no,
       'comments': comments,
       'isOutdoor': isOutdoor ? 1 : 0,
       'timestamp': timestamp.toIso8601String(),

--- a/lib/new_survey/edit_room_reading.dart
+++ b/lib/new_survey/edit_room_reading.dart
@@ -34,6 +34,9 @@ class _EditRoomReadingState extends State<EditRoomReading> {
   late final TextEditingController vocsCtrl;
   late final TextEditingController pm25Ctrl;
   late final TextEditingController pm10Ctrl;
+  late final TextEditingController no2Ctrl;
+  late final TextEditingController so2Ctrl;
+  late final TextEditingController noCtrl2;
   late final TextEditingController commentsCtrl;
   List<File> _imageFiles = [];
 
@@ -52,6 +55,9 @@ class _EditRoomReadingState extends State<EditRoomReading> {
     vocsCtrl = TextEditingController(text: r.vocs?.toString() ?? '');
     pm25Ctrl = TextEditingController(text: r.pm25?.toString() ?? '');
     pm10Ctrl = TextEditingController(text: r.pm10?.toString() ?? '');
+    no2Ctrl = TextEditingController(text: r.no2?.toString() ?? '');
+    so2Ctrl = TextEditingController(text: r.so2?.toString() ?? '');
+    noCtrl2 = TextEditingController(text: r.no?.toString() ?? '');
     commentsCtrl = TextEditingController(text: r.comments);
     _imageFiles = List<File>.from(r.images);
   }
@@ -69,6 +75,9 @@ class _EditRoomReadingState extends State<EditRoomReading> {
     vocsCtrl.dispose();
     pm25Ctrl.dispose();
     pm10Ctrl.dispose();
+    no2Ctrl.dispose();
+    so2Ctrl.dispose();
+    noCtrl2.dispose();
     commentsCtrl.dispose();
     super.dispose();
   }
@@ -122,6 +131,15 @@ class _EditRoomReadingState extends State<EditRoomReading> {
           : null;
       r.pm10 = pm10Ctrl.text.isNotEmpty
           ? parseFlexibleDouble(pm10Ctrl.text)
+          : null;
+      r.no2 = no2Ctrl.text.isNotEmpty
+          ? parseFlexibleDouble(no2Ctrl.text)
+          : null;
+      r.so2 = so2Ctrl.text.isNotEmpty
+          ? parseFlexibleDouble(so2Ctrl.text)
+          : null;
+      r.no = noCtrl2.text.isNotEmpty
+          ? parseFlexibleDouble(noCtrl2.text)
           : null;
       r.comments = commentsCtrl.text;
       r.images = List<File>.from(_imageFiles);
@@ -209,6 +227,27 @@ class _EditRoomReadingState extends State<EditRoomReading> {
                   keyboardType:
                       const TextInputType.numberWithOptions(decimal: true),
                   decoration: const InputDecoration(labelText: 'PM10'),
+                ),
+              if (widget.surveyInfo.no2)
+                TextFormField(
+                  controller: no2Ctrl,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'NO2'),
+                ),
+              if (widget.surveyInfo.so2)
+                TextFormField(
+                  controller: so2Ctrl,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'SO2'),
+                ),
+              if (widget.surveyInfo.no)
+                TextFormField(
+                  controller: noCtrl2,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'NO'),
                 ),
               TextFormField(
                 controller: commentsCtrl,

--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -122,6 +122,9 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
         model.vocs = _checkboxesKey.currentState!.readingsSwitches['VOCs']!;
         model.pm25 = _checkboxesKey.currentState!.readingsSwitches['PM2.5']!;
         model.pm10 = _checkboxesKey.currentState!.readingsSwitches['PM10']!;
+        model.no2 = _checkboxesKey.currentState!.readingsSwitches['NO2']!;
+        model.so2 = _checkboxesKey.currentState!.readingsSwitches['SO2']!;
+        model.no = _checkboxesKey.currentState!.readingsSwitches['NO']!;
       },
       onSaved: (response, values, form) {
         if (values['siteName'].isNotEmpty &&
@@ -446,6 +449,9 @@ class _AllCheckboxesState extends State<AllCheckboxes> {
     'VOCs': false,
     'PM2.5': false,
     'PM10': false,
+    'NO2': false,
+    'SO2': false,
+    'NO': false,
   };
 
   @override
@@ -476,6 +482,9 @@ class _AllCheckboxesState extends State<AllCheckboxes> {
                     checkboxTemplate(context, 'VOCs'),
                     checkboxTemplate(context, 'PM2.5'),
                     checkboxTemplate(context, 'PM10'),
+                    checkboxTemplate(context, 'NO2'),
+                    checkboxTemplate(context, 'SO2'),
+                    checkboxTemplate(context, 'NO'),
                   ],
                 ),
               ),

--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -123,6 +123,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
   final TextEditingController vocsTextController = TextEditingController();
   final TextEditingController pm25TextController = TextEditingController();
   final TextEditingController pm10TextController = TextEditingController();
+  final TextEditingController no2TextController = TextEditingController();
+  final TextEditingController so2TextController = TextEditingController();
+  final TextEditingController noTextController = TextEditingController();
   final TextEditingController commentTextController = TextEditingController();
   final GlobalKey<FormFieldState<String>> buildingDropdownKey =
       GlobalKey<FormFieldState<String>>();
@@ -213,6 +216,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
     vocsTextController.clear();
     pm25TextController.clear();
     pm10TextController.clear();
+    no2TextController.clear();
+    so2TextController.clear();
+    noTextController.clear();
     commentTextController.clear();
     buildingDropdownKey.currentState?.reset();
     floorDropdownKey.currentState?.reset();
@@ -229,6 +235,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
         vocsTextController.text.isNotEmpty ||
         pm25TextController.text.isNotEmpty ||
         pm10TextController.text.isNotEmpty ||
+        no2TextController.text.isNotEmpty ||
+        so2TextController.text.isNotEmpty ||
+        noTextController.text.isNotEmpty ||
         commentTextController.text.isNotEmpty ||
         _imageFiles.isNotEmpty;
   }
@@ -271,6 +280,15 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
             : null,
         pm10: widget.surveyInfo.pm10
             ? parseFlexibleDouble(pm10TextController.text)
+            : null,
+        no2: widget.surveyInfo.no2
+            ? parseFlexibleDouble(no2TextController.text)
+            : null,
+        so2: widget.surveyInfo.so2
+            ? parseFlexibleDouble(so2TextController.text)
+            : null,
+        no: widget.surveyInfo.no
+            ? parseFlexibleDouble(noTextController.text)
             : null,
         comments: commentTextController.text.isEmpty
             ? "No issues were observed."
@@ -766,6 +784,84 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       ),
                       // Define your text input properties here
                     ),
+                  if (widget.surveyInfo.no2)
+                    TextFormField(
+                      controller: no2TextController,
+                      autovalidateMode: AutovalidateMode.always,
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: false),
+                      validator: (value) {
+                        if (value == null) {
+                          return null;
+                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)\$').hasMatch(value)) {
+                          return "Enter Correct NO2 Value";
+                        } else {
+                          return null;
+                        }
+                      },
+                      onEditingComplete: () {
+                        bool seen = false;
+                        if (!seen && (parseFlexibleDouble(no2TextController.text) ?? double.negativeInfinity) > 1.0) {
+                          seen = true;
+                          _showConfirmValueDialog(context, 'NO2');
+                        }
+                      },
+                      decoration: const InputDecoration(
+                        labelText: 'NO2',
+                        suffixText: 'PPM',
+                      ),
+                    ),
+                  if (widget.surveyInfo.so2)
+                    TextFormField(
+                      controller: so2TextController,
+                      autovalidateMode: AutovalidateMode.always,
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: false),
+                      validator: (value) {
+                        if (value == null) {
+                          return null;
+                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)\$').hasMatch(value)) {
+                          return "Enter Correct SO2 Value";
+                        } else {
+                          return null;
+                        }
+                      },
+                      onEditingComplete: () {
+                        bool seen = false;
+                        if (!seen && (parseFlexibleDouble(so2TextController.text) ?? double.negativeInfinity) > 1.0) {
+                          seen = true;
+                          _showConfirmValueDialog(context, 'SO2');
+                        }
+                      },
+                      decoration: const InputDecoration(
+                        labelText: 'SO2',
+                        suffixText: 'PPM',
+                      ),
+                    ),
+                  if (widget.surveyInfo.no)
+                    TextFormField(
+                      controller: noTextController,
+                      autovalidateMode: AutovalidateMode.always,
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: false),
+                      validator: (value) {
+                        if (value == null) {
+                          return null;
+                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)\$').hasMatch(value)) {
+                          return "Enter Correct NO Value";
+                        } else {
+                          return null;
+                        }
+                      },
+                      onEditingComplete: () {
+                        bool seen = false;
+                        if (!seen && (parseFlexibleDouble(noTextController.text) ?? double.negativeInfinity) > 1.0) {
+                          seen = true;
+                          _showConfirmValueDialog(context, 'NO');
+                        }
+                      },
+                      decoration: const InputDecoration(
+                        labelText: 'NO',
+                        suffixText: 'PPM',
+                      ),
+                    ),
                   TextFormField(
                     controller: commentTextController,
                     decoration: const InputDecoration(
@@ -938,6 +1034,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
     vocsTextController.dispose();
     pm25TextController.dispose();
     pm10TextController.dispose();
+    no2TextController.dispose();
+    so2TextController.dispose();
+    noTextController.dispose();
     commentTextController.dispose();
     temperatureFocusNode.dispose();
     super.dispose();

--- a/scripts/firebase_export.py
+++ b/scripts/firebase_export.py
@@ -87,7 +87,7 @@ def export_iaq(header, rooms, output_dir, template_path='assets/IAQ_template_v2.
     if first_outdoor:
         rooms.remove(first_outdoor)
         rooms.insert(0, first_outdoor)
-    stats = {'temp': [], 'rh': [], 'co2': [], 'pm25': []}
+    stats = {'temp': [], 'rh': [], 'co2': [], 'pm25': [], 'no2': [], 'so2': [], 'no': [], 'co': [], 'pm10': [], 'vocs': []}
     for i, r in enumerate(rooms, start=0):
         row_idx = template_idx + i
         copy_row_style(ws, template_idx, row_idx)
@@ -99,10 +99,22 @@ def export_iaq(header, rooms, output_dir, template_path='assets/IAQ_template_v2.
         rh = r.get('relativeHumidity') or r.get('relativeHumidityPct')
         co2 = r.get('co2') or r.get('co2ppm')
         pm25 = r.get('pm25') or r.get('pm25mgm3')
+        pm10 = r.get('pm10')
+        vocs = r.get('vocs')
+        no2 = r.get('no2')
+        so2 = r.get('so2')
+        no = r.get('no')
+        co = r.get('co')
         ws.cell(row=row_idx, column=5, value=t)
         ws.cell(row=row_idx, column=6, value=rh)
         ws.cell(row=row_idx, column=7, value=co2)
         ws.cell(row=row_idx, column=8, value=pm25)
+        ws.cell(row=row_idx, column=9, value=pm10)
+        ws.cell(row=row_idx, column=10, value=vocs)
+        ws.cell(row=row_idx, column=11, value=no2)
+        ws.cell(row=row_idx, column=12, value=so2)
+        ws.cell(row=row_idx, column=13, value=no)
+        ws.cell(row=row_idx, column=14, value=co)
         if t is not None:
             stats['temp'].append(t)
         if rh is not None:
@@ -111,6 +123,18 @@ def export_iaq(header, rooms, output_dir, template_path='assets/IAQ_template_v2.
             stats['co2'].append(co2)
         if pm25 is not None:
             stats['pm25'].append(pm25)
+        if pm10 is not None:
+            stats['pm10'].append(pm10)
+        if vocs is not None:
+            stats['vocs'].append(vocs)
+        if no2 is not None:
+            stats['no2'].append(no2)
+        if so2 is not None:
+            stats['so2'].append(so2)
+        if no is not None:
+            stats['no'].append(no)
+        if co is not None:
+            stats['co'].append(co)
 
     # min & max sheet
     mm = wb.create_sheet('Min&Max') if 'Min&Max' not in wb.sheetnames else wb['Min&Max']
@@ -126,6 +150,12 @@ def export_iaq(header, rooms, output_dir, template_path='assets/IAQ_template_v2.
     write_stat(3, 'Relative Humidity (%)', stats['rh'])
     write_stat(4, 'CO2 (ppm)', stats['co2'])
     write_stat(5, 'PM2.5 (ug/m3)', stats['pm25'])
+    write_stat(6, 'PM10 (ug/m3)', stats['pm10'])
+    write_stat(7, 'VOCs', stats['vocs'])
+    write_stat(8, 'NO2 (ppm)', stats['no2'])
+    write_stat(9, 'SO2 (ppm)', stats['so2'])
+    write_stat(10, 'NO (ppm)', stats['no'])
+    write_stat(11, 'CO (ppm)', stats['co'])
 
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, f"{site_name.replace(' ', '_')}_IAQ_{date.strftime('%Y%m%d')}.xlsx")


### PR DESCRIPTION
## Summary
- extend `SurveyInfo` and `RoomReading` to store NO₂, SO₂ and NO readings
- update database schema and upgrade logic for new fields
- expose new gas options in new survey flow and room editing screens
- export new readings in Excel and Firebase export

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2176ea188322acd85bc75db5e347