### PR TITLE
Use env for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Learn more at [sohum1094.github.io](url)
 
 After the configuration files are in place, the app can initialize Firebase using the generated options.
 
+## Environment Variables
+
+Sensitive values such as the Google Maps API keys and the URL of the Cloud Function used for Word report generation are loaded from a `.env` file at runtime. Create your own `.env` by copying `example.env` and filling in the appropriate values:
+
+```bash
+cp example.env .env
+```
+
+The application reads these variables using the `flutter_dotenv` package.
+
 ### Enable Authentication
 
 To authenticate users, enable Email/Password sign-in in the Firebase console:

--- a/example.env
+++ b/example.env
@@ -1,0 +1,4 @@
+# Example environment variables for IAQuick
+ANDROID_GOOGLE_API_KEY=your-android-google-api-key
+IOS_GOOGLE_API_KEY=your-ios-google-api-key
+GENERATE_REPORT_URL=https://your-cloud-function-url

--- a/lib/existing_survey_screen.dart
+++ b/lib/existing_survey_screen.dart
@@ -21,7 +21,6 @@ import 'package:image/image.dart' as img_lib;
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'api_keys.dart';
 
 
 class ExistingSurveyScreen extends StatefulWidget {
@@ -901,7 +900,7 @@ Future<File?> generateWordReport(SurveyInfo info) async {
     print('📤 Sending to generate-iaq-report: $payload');
 
     final resp = await http.post(
-      Uri.parse(generate_report_url),
+      Uri.parse(dotenv.env['GENERATE_REPORT_URL'] ?? ''),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode(payload),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'auth/sign_in_screen.dart';
 import 'auth_service.dart';
@@ -15,6 +16,7 @@ final SurveyService surveyService = SurveyService();
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load(fileName: '.env');
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );

--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -32,7 +32,7 @@ import 'package:iaqapp/new_survey/room_readings.dart';
 import 'package:iaqapp/models/survey_info.dart';
 import 'package:intl/intl.dart';
 import 'package:google_places_flutter/google_places_flutter.dart';
-import 'package:iaqapp/api_keys.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'dart:io' show Platform;
 import 'package:http/http.dart' as http;
 import 'dart:convert';
@@ -258,10 +258,10 @@ EasyTextFormField addressTextFormField(
       if (tempAddress != null) model.address = tempAddress;
     },
     builder: (state, onChanged) {
-      // pick your platform-specific key
+      // pick your platform-specific key from env
       final apiKey = Platform.isIOS
-          ? ios_google_api_key
-          : android_google_api_key;
+          ? dotenv.env['IOS_GOOGLE_API_KEY']
+          : dotenv.env['ANDROID_GOOGLE_API_KEY'];
 
       return GooglePlaceAutoCompleteTextField(
         textEditingController: controller,


### PR DESCRIPTION
## Summary
- load environment variables using flutter_dotenv
- retrieve Google Maps keys and report URL from the .env file
- document environment variable setup in README
- add `example.env` template

## Testing
- `python3 -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686186b52d5083229fbd02a76121bad4