### PR TITLE
Fix duplicate Firebase initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,9 +17,13 @@ final SurveyService surveyService = SurveyService();
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  } else {
+    Firebase.app();
+  }
   await SurveyService.configureFirestoreCache();
   await surveyService.startConnectivityListener();
   await FirebaseAppCheck.instance.activate(


### PR DESCRIPTION
## Summary
- avoid initializing Firebase a second time by checking `Firebase.apps.isEmpty`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863165ed65883228603de710c3256e5