### PR TITLE
Fix optional decimal validation for new readings

### DIFF
--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -253,7 +253,7 @@ EasyTextFormField addressTextFormField(
                 final data = json.decode(resp.body);
                 final formatted = data['result']?['formatted_address'];
                 if (formatted is String && formatted.isNotEmpty) {
-                  address = formatted.replaceAll(RegExp(r',?\\s*USA\$'), '');
+                  address = formatted.replaceAll(RegExp(r',?\\s*USA$'), '');
                 }
               }
             } catch (_) {}

--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -763,7 +763,7 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       validator: (value) {
                         if (value == null) {
                           return null;
-                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)\$').hasMatch(value)) {
+                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)$').hasMatch(value)) {
                           return "Enter Correct NO2 Value";
                         } else {
                           return null;
@@ -789,7 +789,7 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       validator: (value) {
                         if (value == null) {
                           return null;
-                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)\$').hasMatch(value)) {
+                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)$').hasMatch(value)) {
                           return "Enter Correct SO2 Value";
                         } else {
                           return null;
@@ -815,7 +815,7 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       validator: (value) {
                         if (value == null) {
                           return null;
-                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)\$').hasMatch(value)) {
+                        } else if (value.isNotEmpty && !RegExp(r'^(?:\\d+(?:\\.\\d+)?|\\.\\d+)$').hasMatch(value)) {
                           return "Enter Correct NO Value";
                         } else {
                           return null;


### PR DESCRIPTION
## Summary
- fix regex for optional NO2, SO2, and NO reading validators
- fix USA address regex

## Testing
- `sed -n '760,830p' lib/new_survey/room_readings.dart`
- `sed -n '256p' lib/new_survey/new_survey_start.dart`


------
https://chatgpt.com/codex/tasks/task_e_686d9a1902a8832295a2e102ce994f03