### PR TITLE
Improve camera permission flow and keyboard layout

### DIFF
--- a/lib/new_survey/edit_room_reading.dart
+++ b/lib/new_survey/edit_room_reading.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:iaqapp/models/survey_info.dart';
 import 'package:iaqapp/new_survey/room_readings.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:iaqapp/utils.dart';
 import 'dart:io';
 
@@ -83,19 +82,14 @@ class _EditRoomReadingState extends State<EditRoomReading> {
   }
 
   Future<void> _getImage() async {
-    final status = await Permission.camera.request();
     final picker = ImagePicker();
+    final permissionGranted = await requestCameraPermission(context);
     XFile? pickedImage;
-    if (status.isGranted) {
+
+    if (permissionGranted) {
       pickedImage = await picker.pickImage(source: ImageSource.camera);
-    } else if (status.isDenied) {
-      pickedImage = await picker.pickImage(source: ImageSource.gallery);
     } else {
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Camera permission denied')),
-      );
-      return;
+      pickedImage = await picker.pickImage(source: ImageSource.gallery);
     }
 
     if (!mounted) return;

--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -26,7 +26,7 @@ class NewSurveyStart extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        resizeToAvoidBottomInset: true,
+        resizeToAvoidBottomInset: false,
         appBar: AppBar(
           title: const Text('New Survey Information'),
           centerTitle: true,
@@ -115,16 +115,15 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
           padding: EdgeInsets.only(
             bottom: MediaQuery.of(context).viewInsets.bottom,
           ),
-          child: SizedBox(
-            height: MediaQuery.of(context).size.height * .9,
-            child: Center(
-              child: Column(
-                children: [
-                  siteNameTextFormField(context, model),
-                  projectNumberTextFormField(context, model),
-                  addressTextFormField(
-                      context, model, _addressController, _addressFocusNode),
-                  DateTimePicker(model: model),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                siteNameTextFormField(context, model),
+                projectNumberTextFormField(context, model),
+                addressTextFormField(
+                    context, model, _addressController, _addressFocusNode),
+                DateTimePicker(model: model),
                   occupancyTypeDropdown(context, model),
                   AllCheckboxes(key: _checkboxesKey, flex: 2),
                   EasyFormSaveButton.text('Submit'),

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,3 +1,5 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
 double? parseFlexibleDouble(String? value) {
   if (value == null || value.isEmpty) return null;
   final normalized = value.startsWith('.')
@@ -6,4 +8,16 @@ double? parseFlexibleDouble(String? value) {
           ? value.replaceFirst('-.', '-0.')
           : value;
   return double.tryParse(normalized);
+}
+
+/// Whether the camera permission request has been shown before.
+Future<bool> wasCameraPermissionRequested() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getBool('cameraPermissionRequested') ?? false;
+}
+
+/// Mark that the camera permission request was shown.
+Future<void> markCameraPermissionRequested() async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setBool('cameraPermissionRequested', true);
 }


### PR DESCRIPTION
## Summary
- prompt for camera permission only on first photo attempt using shared prefs
- update add photo workflows accordingly
- make keyboard overlay instead of resizing on new survey start screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687093917bac83229cdd005b412762dd