### PR TITLE
Add Apple sign in option

### DIFF
--- a/lib/auth/sign_in_screen.dart
+++ b/lib/auth/sign_in_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'dart:io' show Platform;
 import '../auth_service.dart';
 import 'sign_up_screen.dart';
 
@@ -102,6 +103,21 @@ class _SignInScreenState extends State<SignInScreen> {
               },
               child: const Text('Sign In with Google'),
             ),
+            if (Platform.isIOS) ...[
+              const SizedBox(height: 10),
+              ElevatedButton(
+                onPressed: () async {
+                  try {
+                    await authService.signInWithApple();
+                  } on FirebaseAuthException catch (e) {
+                    setState(() {
+                      _error = e.message;
+                    });
+                  }
+                },
+                child: const Text('Sign In with Apple'),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/auth_service.dart
+++ b/lib/auth_service.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
@@ -33,6 +34,22 @@ class AuthService {
       idToken: googleAuth.idToken,
     );
     return _auth.signInWithCredential(credential);
+  }
+
+  Future<UserCredential> signInWithApple() async {
+    final appleCredential = await SignInWithApple.getAppleIDCredential(
+      scopes: [
+        AppleIDAuthorizationScopes.email,
+        AppleIDAuthorizationScopes.fullName,
+      ],
+    );
+
+    final oauthCredential = OAuthProvider('apple.com').credential(
+      idToken: appleCredential.identityToken,
+      accessToken: appleCredential.authorizationCode,
+    );
+
+    return _auth.signInWithCredential(oauthCredential);
   }
 
   Future<void> signOut() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   cloud_functions: ^5.5.2
 
   google_sign_in: ^6.2.1
+  sign_in_with_apple: ^7.0.1
   connectivity_plus: ^6.1.4
   sqflite: ^2.3.2
   uuid: ^4.2.2

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,6 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
+import 'dart:io' show Platform;
 
 import 'package:iaqapp/auth_service.dart';
 import 'package:iaqapp/auth/sign_in_screen.dart';
@@ -26,5 +27,8 @@ void main() {
     expect(find.text('Sign In'), findsOneWidget);
     expect(find.text('Create Account'), findsOneWidget);
     expect(find.text('Sign In with Google'), findsOneWidget);
+    if (Platform.isIOS) {
+      expect(find.text('Sign In with Apple'), findsOneWidget);
+    }
   });
 }


### PR DESCRIPTION
## Summary
- add `sign_in_with_apple` dependency
- support signing in with Apple in `AuthService`
- show a Sign In with Apple button under the Google sign in button on iOS
- update widget test to verify presence of the Apple button on iOS

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712649c5e88322810c2c4f09a71f48