### PR TITLE
Improve sign-in screen

### DIFF
--- a/lib/auth/sign_in_screen.dart
+++ b/lib/auth/sign_in_screen.dart
@@ -30,9 +30,10 @@ class _SignInScreenState extends State<SignInScreen> {
           child: Image.asset('assets/IAQuick_icon.png'),
         ),
       ),
-      body: Padding(
+      body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
             Padding(
               padding: const EdgeInsets.only(bottom: 24.0),
@@ -43,6 +44,7 @@ class _SignInScreenState extends State<SignInScreen> {
             ),
             TextField(
               controller: _emailController,
+              keyboardType: TextInputType.emailAddress,
               decoration: const InputDecoration(labelText: 'Email'),
             ),
             TextField(
@@ -100,7 +102,9 @@ class _SignInScreenState extends State<SignInScreen> {
               child: const Text('Create Account'),
             ),
             const SizedBox(height: 10),
-            ElevatedButton(
+            ElevatedButton.icon(
+              icon: Image.asset('assets/icons/google.png', height: 24),
+              label: const Text('Sign In with Google'),
               onPressed: () async {
                 try {
                   final cred = await authService.signInWithGoogle();
@@ -117,12 +121,13 @@ class _SignInScreenState extends State<SignInScreen> {
                     _error = e.message;
                   });
                 }
-              },
-              child: const Text('Sign In with Google'),
+                },
             ),
             if (Platform.isIOS) ...[
               const SizedBox(height: 10),
-              ElevatedButton(
+              ElevatedButton.icon(
+                icon: Image.asset('assets/icons/apple.png', height: 24),
+                label: const Text('Sign In with Apple'),
                 onPressed: () async {
                   try {
                     final cred = await authService.signInWithApple();
@@ -140,7 +145,6 @@ class _SignInScreenState extends State<SignInScreen> {
                     });
                   }
                 },
-                child: const Text('Sign In with Apple'),
               ),
             ],
           ],


### PR DESCRIPTION
## Summary
- fix keyboard overflow on sign in
- use email keyboard for email entry
- show Google and Apple logos on social sign in buttons
- assume icon assets are already present rather than bundling them

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687158bdc9a8832283c8cfbfeb44fb71