### PR TITLE
Wrap Firebase init logs with debug checks

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,9 +29,11 @@ void main() async {
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,
     );
-    print('✅ Firebase initialised by Dart.');
+    if (kDebugMode) {
+      print('✅ Firebase initialised by Dart.');
+    }
   } on FirebaseException catch (e) {
-    if (e.code == 'duplicate-app') {
+    if (e.code == 'duplicate-app' && kDebugMode) {
       print('⚠️ duplicate-app caught – native init already finished.');
     } else {
       rethrow; // Any other error is real and should break.


### PR DESCRIPTION
## Summary
- ensure Firebase initialization logs only appear in debug mode

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687283e63230832292b070bb9fe92aaf