### PR TITLE
Set Firestore log level

### DIFF
--- a/lib/survey_service.dart
+++ b/lib/survey_service.dart
@@ -3,7 +3,8 @@ import 'dart:async';
 
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart'
+    show FirebaseFirestore, LogLevel, Settings;
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -19,6 +20,7 @@ class SurveyService {
     FirebaseFirestore.instance.settings = const Settings(
       persistenceEnabled: true,
       cacheSizeBytes: 15 * 1024 * 1024,
+      logLevel: LogLevel.error,
     );
   }
 


### PR DESCRIPTION
## Summary
- configure `logLevel` for Firestore cache settings to suppress debug messages

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_687283f1d6dc8322869368afc099a368