### PR TITLE
Add photo source selection dialog

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -46,8 +46,10 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSCameraUsageDescription</key>
-	<string>Allow camera access to capture room images to attach to survey.</string>
+       <key>NSCameraUsageDescription</key>
+       <string>Allow camera access to capture room images to attach to survey.</string>
+       <key>NSPhotoLibraryUsageDescription</key>
+       <string>Allow access to your photo library to select room images.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/lib/new_survey/edit_room_reading.dart
+++ b/lib/new_survey/edit_room_reading.dart
@@ -81,21 +81,45 @@ class _EditRoomReadingState extends State<EditRoomReading> {
     super.dispose();
   }
 
-  Future<void> _getImage() async {
-    final picker = ImagePicker();
-    final permissionGranted = await requestCameraPermission(context);
-    XFile? pickedImage;
+  Future<ImageSource?> _selectImageSource() async {
+    return showModalBottomSheet<ImageSource>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('Camera'),
+              onTap: () => Navigator.pop(context, ImageSource.camera),
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('Photo Library'),
+              onTap: () => Navigator.pop(context, ImageSource.gallery),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 
-    if (permissionGranted) {
-      pickedImage = await picker.pickImage(source: ImageSource.camera);
-    } else {
-      pickedImage = await picker.pickImage(source: ImageSource.gallery);
+  Future<void> _getImage() async {
+    final source = await _selectImageSource();
+    if (source == null) return;
+
+    final picker = ImagePicker();
+
+    if (source == ImageSource.camera) {
+      final granted = await requestCameraPermission(context);
+      if (!granted) return;
     }
+
+    final pickedImage = await picker.pickImage(source: source);
 
     if (!mounted) return;
     if (pickedImage != null) {
       setState(() {
-        _imageFiles.add(File(pickedImage!.path));
+        _imageFiles.add(File(pickedImage.path));
       });
     }
   }

--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -139,21 +139,45 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
     }
   }
 
-  Future<void> _getImage() async {
-    bool permissionGranted = await requestCameraPermission(context);
-    final imagePicker = ImagePicker();
-    XFile? pickedImage;
+  Future<ImageSource?> _selectImageSource() async {
+    return showModalBottomSheet<ImageSource>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('Camera'),
+              onTap: () => Navigator.pop(context, ImageSource.camera),
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('Photo Library'),
+              onTap: () => Navigator.pop(context, ImageSource.gallery),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 
-    if (permissionGranted) {
-      pickedImage = await imagePicker.pickImage(source: ImageSource.camera);
-    } else {
-      pickedImage = await imagePicker.pickImage(source: ImageSource.gallery);
+  Future<void> _getImage() async {
+    final source = await _selectImageSource();
+    if (source == null) return;
+
+    final imagePicker = ImagePicker();
+
+    if (source == ImageSource.camera) {
+      final granted = await requestCameraPermission(context);
+      if (!granted) return;
     }
+
+    final pickedImage = await imagePicker.pickImage(source: source);
 
     if (!mounted) return;
     if (pickedImage != null) {
       setState(() {
-        _imageFiles.add(File(pickedImage!.path));
+        _imageFiles.add(File(pickedImage.path));
       });
     }
   }


### PR DESCRIPTION
## Summary
- let users pick Camera or Photo Library before capturing
- show image source selection in room readings and edit room reading screens
- request camera permission only when needed
- add `NSPhotoLibraryUsageDescription` on iOS

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728a19141483228ebe0081bb2fd124