### PR TITLE
Add next keyboard navigation

### DIFF
--- a/lib/new_survey/new_survey_start.dart
+++ b/lib/new_survey/new_survey_start.dart
@@ -61,6 +61,8 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
   final SurveyInfo model = SurveyInfo();
   final GlobalKey<_AllCheckboxesState> _checkboxesKey =
       GlobalKey<_AllCheckboxesState>();
+  final FocusNode _siteNameFocusNode = FocusNode();
+  final FocusNode _projectNumberFocusNode = FocusNode();
   final TextEditingController _addressController = TextEditingController();
   final FocusNode _addressFocusNode = FocusNode();
 
@@ -116,8 +118,18 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                siteNameTextFormField(context, model),
-                projectNumberTextFormField(context, model),
+                siteNameTextFormField(
+                  context,
+                  model,
+                  _siteNameFocusNode,
+                  _projectNumberFocusNode,
+                ),
+                projectNumberTextFormField(
+                  context,
+                  model,
+                  _projectNumberFocusNode,
+                  _addressFocusNode,
+                ),
                 addressTextFormField(
                   context,
                   model,
@@ -140,6 +152,8 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
 
   @override
   void dispose() {
+    _siteNameFocusNode.dispose();
+    _projectNumberFocusNode.dispose();
     _addressController.dispose();
     _addressFocusNode.dispose();
     super.dispose();
@@ -162,10 +176,17 @@ class SurveyInitialInfoFormState extends State<SurveyInitialInfoForm> {
 EasyTextFormField siteNameTextFormField(
   BuildContext context,
   SurveyInfo model,
+  FocusNode focusNode,
+  FocusNode nextFocus,
 ) {
   return EasyTextFormField(
     initialValue: '',
     name: 'siteName',
+    focusNode: focusNode,
+    textInputAction: TextInputAction.next,
+    onFieldSubmitted: (_) {
+      FocusScope.of(context).requestFocus(nextFocus);
+    },
     autovalidateMode: EasyAutovalidateMode.always,
     validator: (value, [values]) {
       if (value == null) {
@@ -188,10 +209,17 @@ EasyTextFormField siteNameTextFormField(
 EasyTextFormField projectNumberTextFormField(
   BuildContext context,
   SurveyInfo model,
+  FocusNode focusNode,
+  FocusNode nextFocus,
 ) {
   return EasyTextFormField(
     initialValue: '',
     name: 'projectNumber',
+    focusNode: focusNode,
+    textInputAction: TextInputAction.next,
+    onFieldSubmitted: (_) {
+      FocusScope.of(context).requestFocus(nextFocus);
+    },
     autovalidateMode: EasyAutovalidateMode.always,
     validator: (value, [values]) {
       if (value == null) {
@@ -240,6 +268,10 @@ EasyTextFormField addressTextFormField(
       return GooglePlaceAutoCompleteTextField(
         textEditingController: controller,
         focusNode: focusNode,
+        textInputAction: TextInputAction.next,
+        onEditingComplete: () {
+          FocusScope.of(context).nextFocus();
+        },
         googleAPIKey: apiKey!,
         debounceTime: 800,
         isLatLngRequired: false,

--- a/lib/new_survey/room_readings.dart
+++ b/lib/new_survey/room_readings.dart
@@ -468,6 +468,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                           controller: roomNumberTextController,
                           autovalidateMode: AutovalidateMode.always,
                           enabled: !isOutdoorReading,
+                          textInputAction: TextInputAction.next,
+                          onFieldSubmitted: (_) =>
+                              FocusScope.of(context).nextFocus(),
                           validator: (value) {
                             if (value == null) {
                               return null;
@@ -487,14 +490,17 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                   ),
 
                   //Primary Use
-                  TextFormField(
-                    controller: primaryUseTextController,
-                    autovalidateMode: AutovalidateMode.always,
-                    keyboardType: TextInputType.text,
-                    enabled: !isOutdoorReading,
-                    validator: (value) {
-                      if (value == null) {
-                        return null;
+                TextFormField(
+                  controller: primaryUseTextController,
+                  autovalidateMode: AutovalidateMode.always,
+                  keyboardType: TextInputType.text,
+                  enabled: !isOutdoorReading,
+                  textInputAction: TextInputAction.next,
+                  onFieldSubmitted: (_) =>
+                      FocusScope.of(context).nextFocus(),
+                  validator: (value) {
+                    if (value == null) {
+                      return null;
                       } else if (value.isNotEmpty &&
                           !RegExp(r'^[a-zA-Z\s\-]+$').hasMatch(value)) {
                         return "Enter Valid Primary Use Value";
@@ -530,6 +536,7 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                           validator: validateRelativeHumidity,
                           keyboardType: const TextInputType.numberWithOptions(
                               decimal: true, signed: false),
+                          textInputAction: TextInputAction.next,
                           onEditingComplete: () {
                             bool seen = false;
 
@@ -543,6 +550,7 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                               _showConfirmValueDialog(
                                   context, 'relative humidity');
                             }
+                            FocusScope.of(context).nextFocus();
                           },
                           onChanged: (value) {
                             bool seen = false;
@@ -570,13 +578,14 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                         flex: 3,
                         child: //Temperature
                             TextFormField(
-                          controller: temperatureTextController,
-                          autovalidateMode: AutovalidateMode.always,
-                          keyboardType: const TextInputType.numberWithOptions(
-                              decimal: true, signed: false),
-                          validator: (value) {
-                            if (value == null) {
-                              return null;
+                              controller: temperatureTextController,
+                              autovalidateMode: AutovalidateMode.always,
+                              keyboardType: const TextInputType.numberWithOptions(
+                                  decimal: true, signed: false),
+                              textInputAction: TextInputAction.next,
+                              validator: (value) {
+                                if (value == null) {
+                                  return null;
                             } else if (value.isNotEmpty &&
                                 !RegExp(r'^(?:\d+(?:\.\d+)?|\.\d+)$').hasMatch(value)) {
                               return "Enter Correct Temperature Value";
@@ -588,14 +597,14 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                           // onChanged: (value) {
                           //   validateTemperatureAndShowDialog();
                           // },
-                          decoration: const InputDecoration(
-                            labelText: "Temperature (F)",
-                            suffixText: 'F',
-                          ),
-                          onEditingComplete: () {
-                            validateTemperatureAndShowDialog();
-                            FocusScope.of(context).unfocus();
-                          },
+                              decoration: const InputDecoration(
+                                labelText: "Temperature (F)",
+                                suffixText: 'F',
+                              ),
+                              onEditingComplete: () {
+                                validateTemperatureAndShowDialog();
+                                FocusScope.of(context).nextFocus();
+                              },
                           // temperature
                         ),
                       ),
@@ -609,6 +618,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       autovalidateMode: AutovalidateMode.always,
                       keyboardType: const TextInputType.numberWithOptions(
                           decimal: true, signed: false),
+                      textInputAction: TextInputAction.next,
+                      onFieldSubmitted: (_) =>
+                          FocusScope.of(context).nextFocus(),
                       validator: (value) {
                         if (value == null) {
                           return null;
@@ -645,6 +657,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       autovalidateMode: AutovalidateMode.always,
                       keyboardType: const TextInputType.numberWithOptions(
                           decimal: true, signed: false),
+                      textInputAction: TextInputAction.next,
+                      onFieldSubmitted: (_) =>
+                          FocusScope.of(context).nextFocus(),
                       validator: (value) {
                         if (value == null) {
                           return null;
@@ -679,6 +694,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       autovalidateMode: AutovalidateMode.always,
                       keyboardType: const TextInputType.numberWithOptions(
                           decimal: true, signed: false),
+                      textInputAction: TextInputAction.next,
+                      onFieldSubmitted: (_) =>
+                          FocusScope.of(context).nextFocus(),
                       validator: (value) {
                         if (value == null) {
                           return null;
@@ -712,6 +730,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       autovalidateMode: AutovalidateMode.always,
                       keyboardType: const TextInputType.numberWithOptions(
                           decimal: true, signed: false),
+                      textInputAction: TextInputAction.next,
+                      onFieldSubmitted: (_) =>
+                          FocusScope.of(context).nextFocus(),
                       validator: (value) {
                         if (value == null) {
                           return null;
@@ -745,6 +766,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       autovalidateMode: AutovalidateMode.always,
                       keyboardType: const TextInputType.numberWithOptions(
                           decimal: true, signed: false),
+                      textInputAction: TextInputAction.next,
+                      onFieldSubmitted: (_) =>
+                          FocusScope.of(context).nextFocus(),
                       validator: (value) {
                         if (value == null) {
                           return null;
@@ -777,6 +801,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       controller: no2TextController,
                       autovalidateMode: AutovalidateMode.always,
                       keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: false),
+                      textInputAction: TextInputAction.next,
+                      onFieldSubmitted: (_) =>
+                          FocusScope.of(context).nextFocus(),
                       validator: (value) {
                         if (value == null) {
                           return null;
@@ -803,6 +830,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       controller: so2TextController,
                       autovalidateMode: AutovalidateMode.always,
                       keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: false),
+                      textInputAction: TextInputAction.next,
+                      onFieldSubmitted: (_) =>
+                          FocusScope.of(context).nextFocus(),
                       validator: (value) {
                         if (value == null) {
                           return null;
@@ -829,6 +859,9 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                       controller: noTextController,
                       autovalidateMode: AutovalidateMode.always,
                       keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: false),
+                      textInputAction: TextInputAction.next,
+                      onFieldSubmitted: (_) =>
+                          FocusScope.of(context).nextFocus(),
                       validator: (value) {
                         if (value == null) {
                           return null;
@@ -858,7 +891,10 @@ class RoomReadingsFormState extends State<RoomReadingsForm> {
                         hintText:
                             'Enter comments, leave empty if no issues are observed.'),
                     keyboardType: TextInputType
-                        .multiline, // Define your text input properties here
+                        .multiline,
+                    textInputAction: TextInputAction.done,
+                    onFieldSubmitted: (_) =>
+                        FocusScope.of(context).unfocus(),
                   ),
                   const SizedBox(
                     height: 20,


### PR DESCRIPTION
## Summary
- enable field-to-field keyboard navigation on the new survey start form
- add Next/Done keyboard actions to room readings entry fields

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872965dff2083229558b88de62bc0ca